### PR TITLE
dispatch op_decoration.filter_html event for filtering a decorated html (fixes #1747)

### DIFF
--- a/lib/widget/opWidgetFormRichTextareaOpenPNE.class.php
+++ b/lib/widget/opWidgetFormRichTextareaOpenPNE.class.php
@@ -291,6 +291,9 @@ class opWidgetFormRichTextareaOpenPNE extends opWidgetFormRichTextarea
       }
     }
 
+    $event = sfContext::getInstance()->getEventDispatcher()->filter(new sfEvent(null, 'op_decoration.filter_html'), $converted);
+    $converted = $event->getReturnValue();
+
     if ($isHtmlTagFollowup)
     {
       $converted = self::htmlTagFollowup($converted);


### PR DESCRIPTION
プラグインからリッチテキストの装飾をop:*タグ以外の方法で行う手段として op_decoration.filter_html イベントを送出するように修正しました

http://redmine.openpne.jp/issues/1747
