### PR TITLE
#1936 の修正

### DIFF
--- a/lib/user/opAnonymousMember.class.php
+++ b/lib/user/opAnonymousMember.class.php
@@ -52,7 +52,7 @@ class opAnonymousMember extends Member
     return false;
   }
 
-  public function getConfig($configName)
+  public function getConfig($configName, $default = null)
   {
     return null;
   }
@@ -146,12 +146,12 @@ class opAnonymousMember extends Member
     return 'everyone';
   }
 
-  public function save()
+  public function save(Doctrine_Connection $conn = null)
   {
     return false;
   }
 
-  public function delete()
+  public function delete(Doctrine_Connection $conn = null)
   {
     return false;
   }


### PR DESCRIPTION
#1936: opAnonymousMember クラスにStrict Standardsエラーが含まれている

http://redmine.openpne.jp/issues/1936

に対する修正です。
