### PR TITLE
fixed opBaseSecurityUser because it delete Cookie for automatic log-in (f

### DIFF
--- a/lib/user/opBaseSecurityUser.class.php
+++ b/lib/user/opBaseSecurityUser.class.php
@@ -68,7 +68,9 @@ abstract class opBaseSecurityUser extends sfBasicSecurityUser
       return true;
     }
 
-    return ($this->generateSiteIdentifier() === $this->storage->read(self::SITE_IDENTIFIER_NAMESPACE));
+    $identifier = $this->storage->read(self::SITE_IDENTIFIER_NAMESPACE);
+
+    return (null === $identifier || $this->generateSiteIdentifier() === $identifier);
   }
 
   public function generateSiteIdentifier()


### PR DESCRIPTION
fixed opBaseSecurityUser because it delete Cookie for automatic log-in (fixes #1985)

http://redmine.openpne.jp/issues/1985

セッションまわりのことなので、チェックの上取り込んでいただければと。
