### PR TITLE
モバイルのナビに存在するルート名かどうかのチェックを追加

### DIFF
--- a/apps/mobile_frontend/modules/default/templates/_nav.php
+++ b/apps/mobile_frontend/modules/default/templates/_nav.php
@@ -5,11 +5,17 @@ foreach ($navs as $nav)
 {
   if (isset($id))
   {
-    $list[] = link_to($nav->getCaption(), $nav->getUri().'?id='.$id);
+    if(op_is_accessible_url($nav->getUri().'?id='.$id))
+    {
+      $list[] = link_to($nav->getCaption(), $nav->getUri().'?id='.$id);
+    }
   }
   else
   {
-    $list[] = link_to($nav->getCaption(), $nav->getUri());
+    if(op_is_accessible_url($nav->getUri()))
+    {
+      $list[] = link_to($nav->getCaption(), $nav->getUri());
+    }
   }
 }
 echo implode(isset($separator) ? $separator : "<br>\n", $list);

--- a/apps/pc_frontend/modules/default/templates/_globalNav.php
+++ b/apps/pc_frontend/modules/default/templates/_globalNav.php
@@ -1,7 +1,7 @@
 <?php if ($navs): ?>
 <ul>
 <?php foreach ($navs as $nav): ?>
-<?php if (op_is_accessable_url($nav->uri)): ?>
+<?php if (op_is_accessible_url($nav->uri)): ?>
 <li id="globalNav_<?php echo op_url_to_id($nav->uri) ?>"><?php echo link_to($nav->caption, $nav->uri) ?></li>
 <?php endif; ?>
 <?php endforeach; ?>

--- a/apps/pc_frontend/modules/default/templates/_localNav.php
+++ b/apps/pc_frontend/modules/default/templates/_localNav.php
@@ -8,7 +8,7 @@
 <?php $uri = $nav->uri; ?>
 <?php endif; ?>
 
-<?php if (op_is_accessable_url($uri)): ?>
+<?php if (op_is_accessible_url($uri)): ?>
 <li id="<?php echo $nav->type ?>_<?php echo op_url_to_id($nav->uri) ?>"><?php echo link_to($nav->caption, $uri); ?></li>
 <?php endif; ?>
 

--- a/lib/helper/opUtilHelper.php
+++ b/lib/helper/opUtilHelper.php
@@ -821,7 +821,7 @@ function op_decoration($string, $is_strip = false, $is_use_stylesheet = null, $i
   return opWidgetFormRichTextareaOpenPNE::toHtml($string, $is_strip, $is_use_stylesheet, $is_html_tag_followup);
 }
 
-function op_is_accessable_url($uri)
+function op_is_accessible_url($uri)
 {
   if ('/' === $uri[0] || preg_match('#^[a-z][a-z0-9\+.\-]*\://#i', $uri))
   {
@@ -838,6 +838,14 @@ function op_is_accessable_url($uri)
   {
     return sfContext::getInstance()->getController()->actionExists($info[1]['module'], $info[1]['action']);
   }
+}
+
+/**
+ * just for BC
+ */
+function op_is_accessable_url($uri)
+{
+ return op_is_accessible_url($uri);
 }
 
 


### PR DESCRIPTION
pc_frontendのナビには存在するルート名かどうかのチェックがあるのですが、モバイルには無いため、一度インストールしたプラグインを削除した際にナビ設定を消し忘れるとモバイルのホームがメンテナンス画面になってしまいます。
http://sns.openpne.jp/communityTopic/7167

この問題の修正のためpc_frotnendのナビのビューを参考にmobile_frontendのナビのビューを修正したのですが、その際アクセス可能なURLが調べるヘルパー関数名が英語的に間違っていたので、ヘルパー関数定義とpc_frontend側も併せて修正しました。
