### PR TITLE
pc_backend_devでi18nのキャッシュに関するwarningが出るのを修正

### DIFF
--- a/apps/pc_backend/config/factories.yml
+++ b/apps/pc_backend/config/factories.yml
@@ -92,13 +92,7 @@ all:
       debug:                false
       untranslated_prefix:  "[T]"
       untranslated_suffix:  "[/T]"
-      cache:
-        class: sfFileCache
-        param:
-          automatic_cleaning_factor: 0
-          cache_dir:                 %SF_I18N_CACHE_DIR%
-          lifetime:                  86400
-          prefix:                    %SF_APP_DIR%
+      cache: ~
 
   routing:
     class: sfPatternRouting


### PR DESCRIPTION
現象と修正内容はこちらに記載しています。
http://redmine.openpne.jp/issues/2516

よろしくお願いします。
