### PR TITLE
メール投稿用アドレスの生成時、ルートとパラメータの区切り文字を自由に設定できるようにする修正

### DIFF
--- a/config/OpenPNE.yml.sample
+++ b/config/OpenPNE.yml.sample
@@ -22,6 +22,9 @@ is_mail_address_contain_hash: true
 # Length of hash for an e-mail address for posting
 mail_address_hash_length: 12
 
+#メールアドレスの区切り文字
+mail_route_separator: "."
+
 # SNS から送信するメールの Envelope From (Return-Path ヘッダ) に指定するアドレス (PHP の safe_mode が有効な環境では指定できません)
 # Envelope From (Return-Path header) address for sending e-mail from the SNS (cannot use if your PHP's safe_mode setting is on)
 #mail_envelope_from: "return@example.com"

--- a/lib/routing/opMailRoute.class.php
+++ b/lib/routing/opMailRoute.class.php
@@ -19,7 +19,8 @@ class opMailRoute extends sfRoute
 {
   protected
     $member = null,
-    $nonAuth = false;
+    $nonAuth = false,
+    $separator = '.';
 
   public function __construct($pattern, array $defaults = array(), array $requirements = array(), array $options = array())
   {
@@ -29,6 +30,7 @@ class opMailRoute extends sfRoute
     {
       $this->nonAuth = $this->options['non_auth'];
     }
+    $this->separator = sfConfig::get('op_mail_route_separator', '.');
   }
 
   public function getMember()
@@ -86,6 +88,11 @@ class opMailRoute extends sfRoute
     foreach ($variables as $variable => $value)
     {
       $url = str_replace($value, urlencode($tparams[$variable]), $url);
+    }
+
+    if ('.' !== $this->separator)
+    {
+      $url = str_replace('.', $this->separator, $url);
     }
 
     return $url;

--- a/lib/routing/opMailRouting.class.php
+++ b/lib/routing/opMailRouting.class.php
@@ -26,4 +26,14 @@ class opMailRouting extends sfPatternRouting
 
     return $url.'@'.sfConfig::get('op_mail_domain');
   }
+  
+  public function parse($url)
+  {
+    $separator = sfConfig::get('op_mail_route_separator');
+    if ('.' != $separator)
+    {
+      $url = str_replace($separator, '.', $url);
+    }
+    return parent::parse($url);
+  }
 }


### PR DESCRIPTION
現在はメール投稿用アドレス生成時にハッシュやパラメータとの区切り文字が「.」に固定されていますが、区切り文字が「+」ではないことで従来OpenPNE2で一般的だったgmailを使ってキャッチオールメールアドレスを実現するという手法が使えなくなっています。
OpenPNE.ymlでの設定により「+」を区切り文字として使う事ができるように修正してみた版です。
取り込んでいただければ幸いです。
よろしくお願いいたします。

※該当チケットをredmineで探したのですが発見できませんでした。
