### PR TITLE
メンバー退会時プロフィール画像のFileが残るのを解消

### DIFF
--- a/lib/model/doctrine/Member.class.php
+++ b/lib/model/doctrine/Member.class.php
@@ -312,6 +312,12 @@ class Member extends BaseMember implements opAccessControlRecordInterface
       $adminCommunityMember = $communityMemberTable->retrieveByMemberIdAndCommunityId($this->getId(), $communityId);
       $adminCommunityMember->delete();
     }
+    
+    foreach ($this->getMemberImage() as $memberImage)
+    {
+      $memberImage->delete();
+    }
+    
     return parent::delete($conn);
   }
 


### PR DESCRIPTION
メンバー退会時、member_imageはDB側のonDelete: cascadeで消えますが、実際のプロフィール画像のデータがfileテーブルに残ってしまうのを回避する修正です。

現象を発見されたのはconsさんで、下記公式SNSの日記に詳細が記載されています。
http://sns.openpne.jp/diary/27577

よろしくお願いします。
