### PR TITLE
#2904 の修正

### DIFF
--- a/data/upgrade/2/opUpgradeFrom2MemberProfileStrategy.class.php
+++ b/data/upgrade/2/opUpgradeFrom2MemberProfileStrategy.class.php
@@ -114,6 +114,7 @@ class opUpgradeFrom2MemberProfileStrategy extends opUpgradeAbstractStrategy
     $date = $this->conn->expression->concat('birth_year', '"-"', 'birth_month', '"-"' , 'birth_day');
     $this->conn->execute('INSERT INTO member_profile (id, member_id, profile_id, profile_option_id, value, value_datetime, public_flag, tree_key, lft, rgt, level, created_at, updated_at) (SELECT NULL, c_member_id, ?, NULL, '.$date.', '.$date.', public_flag_birth_month_day, NULL, 1, 2, 0, NOW(), NOW() FROM c_member WHERE birth_year <> 0 AND birth_month <> 0 AND birth_day <> 0)', array($birthdayId));
     $this->conn->execute('UPDATE member_profile SET tree_key = id WHERE profile_id = ?', array($birthdayId));
+    $this->conn->execute('UPDATE member_profile SET value = date_format(value_datetime, "%Y-%m-%d") WHERE profile_id = ?', array($birthdayId));
   }
 
   protected function setMemberProfiles($ids)


### PR DESCRIPTION
Bug（バグ） #2904
OpenPNE2系からコンバートした環境で誕生日によるメンバー検索の結果に該当するはずのメンバーがヒットしない現象が発生する場合がある
https://redmine.openpne.jp/issues/2904
