### PR TITLE
#3245の修正

### DIFF
--- a/apps/api/modules/activity/actions/actions.class.php
+++ b/apps/api/modules/activity/actions/actions.class.php
@@ -150,6 +150,11 @@ class activityActions extends opJsonApiActions
 
   public function executePost(sfWebRequest $request)
   {
+    if (!opConfig::get('is_allow_post_activity'))
+    {
+      return $this->renderJSON(array('status' => 'error', 'message' => "you are not allowed this action."));
+    }
+
     $body = (string)$request['body'];
     $this->forward400If('' === $body, 'body parameter not specified.');
 


### PR DESCRIPTION
#3245:スマートフォン api でアクティビティ投稿を行う際に管理画面の「アクティビティ投稿設定」を反映しない

https://redmine.openpne.jp/issues/3245
に対する修正です。

設定値のチェックを追加しました。
