### PR TITLE
#3277の修正

### DIFF
--- a/apps/pc_frontend/modules/default/actions/customizingCssAction.class.php
+++ b/apps/pc_frontend/modules/default/actions/customizingCssAction.class.php
@@ -28,9 +28,9 @@ class customizingCssAction extends sfAction
     $dir = sfConfig::get('sf_web_dir').DIRECTORY_SEPARATOR.'cache'.DIRECTORY_SEPARATOR.'css';
     @$filesystem->mkdirs($dir);
     $filesystem->chmod($dir, 0777);
-    $csspath = $dir.DIRECTORY_SEPARATOR.'customizing.css';
-    file_put_contents($csspath, $css);
-    $filesystem->chmod($csspath, 0666);
+    $cssPath = $dir.DIRECTORY_SEPARATOR.'customizing.css';
+    file_put_contents($cssPath, $css);
+    $filesystem->chmod($cssPath, 0666);
 
     return sfView::NONE;
   }


### PR DESCRIPTION
#3277:customizing.cssが生成された場合削除できない場合がある

https://redmine.openpne.jp/issues/3277
に対する修正です。

web/cache/cssのパーミッションを777に
web/cache/css/customizing.cssのパーミッションを666に変更します。
