### PR TITLE
#3256の修正

### DIFF
--- a/lib/widget/opWidgetFormRichTextarea.class.php
+++ b/lib/widget/opWidgetFormRichTextarea.class.php
@@ -28,6 +28,7 @@ class opWidgetFormRichTextarea extends sfWidgetFormTextarea
     'theme_advanced_buttons1' => 'bold, italic, undefined, forecolor, hr',
     'theme_advanced_buttons2' => '',
     'theme_advanced_buttons3' => '',
+    'convert_urls' => 0,
   );
 
   public function __construct($options = array(), $attributes = array())


### PR DESCRIPTION
#3256(BR from #2495):HTML挿入で テキストモード→プレビューモード→テキストモード の切り替えを行うとリンクの遷移先の指定が変更されてしまう場合がある

https://redmine.openpne.jp/issues/3256
に対する修正です。

tiny_MCEの設定値(convert_urls)が'1'と設定されていたため、'0'に変更しました。
