### PR TITLE
#2882の修正

### DIFF
--- a/lib/validator/opValidatorDate.class.php
+++ b/lib/validator/opValidatorDate.class.php
@@ -99,7 +99,7 @@ class opValidatorDate extends sfValidatorDate
 
     // if one date value is empty, all others must be empty too
     $empties =
-      (!isset($value['year']) || !$value['year'] ? 1 : 0) +
+      (!isset($value['year']) || ('0' != $value['year'] && !$value['year']) ? 1 : 0) +
       (!isset($value['month']) || !$value['month'] ? 1 : 0) +
       (!isset($value['day']) || !$value['day'] ? 1 : 0);
 
@@ -151,5 +151,13 @@ class opValidatorDate extends sfValidatorDate
     }
 
     return $clean;
+  }
+
+  /**
+   * @see sfValidatorBase
+   */
+  protected function isEmpty($value)
+  {
+    return in_array($value, array(null, '', array()), true);
   }
 }

--- a/test/unit/validator/opValidatorDateTest.php
+++ b/test/unit/validator/opValidatorDateTest.php
@@ -2,7 +2,7 @@
 
 include_once dirname(__FILE__) . '/../../bootstrap/unit.php';
 
-$t = new lime_test(42, new lime_output_color());
+$t = new lime_test(44, new lime_output_color());
 
 $v = new opValidatorDate();
 
@@ -47,7 +47,7 @@ $t->is($v->clean(array('year' => '2005', 'month' => '10', 'day' => '15')), '2005
 $t->is($v->clean(array('year' => 2008, 'month' => 02, 'day' => 29)), '2008-02-29', '->clean() recognises a leapyear');
 
 $v->setOption('required', false);
-$v->setOption('empty_value', new DateTime('1989-01-08')); 
+$v->setOption('empty_value', new DateTime('1989-01-08'));
 $t->is($v->clean(array('year' => '', 'month' => '', 'day' => '', 'hour' => '10')), '1989-01-08', '->clean() accepts an array as empty');
 $v->setOption('required', true);
 
@@ -211,3 +211,17 @@ catch (sfValidatorError $e)
 {
   $t->pass('->clean() throws an exception if the date is not within the range provided by the min/max options');
 }
+
+$t->diag('opValidatorDate zero year test');
+$v->setOption('required', false);
+try
+{
+  $v->clean(array('year' => '0', 'month' => '', 'day' => ''));
+  $t->fail('->clean() throws a sfValidatorError if the date is not valid');
+}
+catch (sfValidatorError $e)
+{
+  $t->pass('->clean() throws a sfValidatorError if the date is not valid');
+  $t->is($e->getCode(), 'invalid', '->clean() throws a sfValidatorError');
+}
+$v->setOption('required', true);


### PR DESCRIPTION
#2882:opValidatorDate で「年」に 0 を入力した場合に空値として認識される

https://redmine.openpne.jp/issues/2882
に対する修正です。

isEmptyをopValidatorDate内で実装するように変更しました。
