### PR TITLE
#3267の修正

### DIFF
--- a/lib/vendor/symfony/lib/form/sfForm.class.php
+++ b/lib/vendor/symfony/lib/form/sfForm.class.php
@@ -222,6 +222,8 @@ class sfForm implements ArrayAccess, Iterator, Countable
       $this->taintedFiles = array();
     }
 
+    $this->checkTaintedValues($this->taintedValues);
+
     try
     {
       $this->doBind(self::deepArrayUnion($this->taintedValues, self::convertFileInformation($this->taintedFiles)));
@@ -1335,5 +1337,25 @@ class sfForm implements ArrayAccess, Iterator, Countable
     }
 
     return $array1;
+  }
+
+  /**
+   * Checks that the $_POST values do not contain something that
+   * looks like a file upload (coming from $_FILE).
+   */
+  protected function checkTaintedValues($values)
+  {
+    foreach ($values as $name => $value)
+    {
+      if (!is_array($value)) {
+        continue;
+      }
+
+      if (isset($value['tmp_name'])) {
+        throw new InvalidArgumentException('Do not try to fake a file upload.');
+      }
+
+      $this->checkTaintedValues($value);
+    }
   }
 }

--- a/lib/vendor/symfony/test/unit/form/sfFormTest.php
+++ b/lib/vendor/symfony/test/unit/form/sfFormTest.php
@@ -10,7 +10,7 @@
 
 require_once(dirname(__FILE__).'/../../bootstrap/unit.php');
 
-$t = new lime_test(163);
+$t = new lime_test(165);
 
 class FormTest extends sfForm
 {
@@ -979,3 +979,46 @@ $f = new NumericFieldsForm(array('5' => 'default'));
 $t->is_deeply($f->getFormFieldSchema()->getValue(), array('5' => 'default'), '->getFormFieldSchema() includes default numeric fields');
 $f->bind(array('5' => 'bound'));
 $t->is_deeply($f->getFormFieldSchema()->getValue(), array('5' => 'bound'), '->getFormFieldSchema() includes bound numeric fields');
+
+// bind with a simulated file upload in the POST array
+$f = new FormTest();
+try
+{
+  $f->bind(array(
+    'file' => array(
+      'name' => 'foo.txt',
+      'type' => 'text/plain',
+      'tmp_name' => 'somefile',
+      'error' => 0,
+      'size' => 10,
+     ),
+  ));
+  $t->fail('Cannot fake a file upload with a POST');
+}
+catch (InvalidArgumentException $e)
+{
+  $t->pass('Cannot fake a file upload with a POST');
+}
+
+$f = new FormTest();
+try
+{
+  $f->bind(array(
+      'foo' => array(
+        'bar' => array(
+          'file' => array(
+            'name' => 'foo.txt',
+            'type' => 'text/plain',
+            'tmp_name' => 'somefile',
+            'error' => 0,
+            'size' => 10,
+          ),
+        ),
+      ),
+  ));
+  $t->fail('Cannot fake a file upload with a POST');
+}
+catch (InvalidArgumentException $e)
+{
+  $t->pass('Cannot fake a file upload with a POST');
+}


### PR DESCRIPTION
#3267:symfony1.4.20リリースされたsecurity fixを取り込む

https://redmine.openpne.jp/issues/3267
に対する修正です。

パッチ取り込みを行いました。
