### PR TITLE
(fixes #3323) Search for members in the member ID

### DIFF
--- a/apps/pc_backend/modules/member/actions/actions.class.php
+++ b/apps/pc_backend/modules/member/actions/actions.class.php
@@ -36,7 +36,7 @@ class memberActions extends sfActions
   {
     $params = $request->getParameter('member', array());
 
-    $this->form = new opMemberProfileSearchForm(array(), array('use_id' => true, 'is_check_public_flag' => false));
+    $this->form = new opMemberProfileSearchForm(array(), array('is_use_id' => true, 'is_check_public_flag' => false));
     $this->form->getWidgetSchema()->setLabel('name', 'Nickname');
     $this->form->bind($params);
 


### PR DESCRIPTION
http://redmine.openpne.jp/issues/3323
管理画面のメンバー管理にてメンバーIDでの絞り込みができない。
の修正です。
