### PR TITLE
#3330の修正

### DIFF
--- a/lib/action/opJsonApiActions.class.php
+++ b/lib/action/opJsonApiActions.class.php
@@ -42,7 +42,6 @@ class opJsonApiActions extends sfActions
   public function renderJSON(array $data)
   {
     $json = json_encode($data, $this->doEscape);
-    $this->getResponse()->setContentType('application/json');
 
     return $this->renderText($json);
   }


### PR DESCRIPTION
#3330:opJsonApiActions 内で Content-Type の設定が2度呼び出されている

https://redmine.openpne.jp/issues/3330
に対する修正です。

該当行の削除を行いました。
cherry-pickで取り込むと他チケット(#3028)の修正分も入ってしまうため、手動で削除しています。
