### PR TITLE
#3331の修正

### DIFF
--- a/lib/util/opActivityQueryBuilder.class.php
+++ b/lib/util/opActivityQueryBuilder.class.php
@@ -187,7 +187,7 @@ class opActivityQueryBuilder
       $query->andWhere('a.member_id = ?', $memberId);
     }
 
-    $query->andWhereIn('a.public_flag', $this->table->getViewablePublicFlags($publicFlag));
+    $query->andWhere('a.public_flag <= ?', $publicFlag);
 
     return $query;
   }


### PR DESCRIPTION
#3331:activity/search.json?member_id=? で特定メンバーのアクティビティを取得すると500エラーとなる

https://redmine.openpne.jp/issues/3331
に対する修正です。

(#3273)af729c356aa54780e6a2a2e4870efd1db21a42f3
を取り込みました。
