### PR TITLE
remove useless include in designActionsTest.php (fixes #3460, BP from #3425)

### DIFF
--- a/test/functional/pc_backend/designActionsTest.php
+++ b/test/functional/pc_backend/designActionsTest.php
@@ -1,6 +1,5 @@
 <?php
 
-include(dirname(__FILE__).'/../../bootstrap/database.php');
 include(dirname(__FILE__).'/../../bootstrap/functional.php');
 
 $browser = new opTestFunctional(new opBrowser(), new lime_test(null, new lime_output_color()));


### PR DESCRIPTION
remove useless include in designActionsTest.php (fixes #3460, BP from #3425)

(cherry picked from commit 74943a28fb7cb3da51dd3bae47283708a266540f)
