### PR TITLE
#3416のBP#3497のコミットを3件分

### DIFF
--- a/lib/action/opMemberAction.class.php
+++ b/lib/action/opMemberAction.class.php
@@ -161,7 +161,6 @@ abstract class opMemberAction extends sfActions
 
   public function executeRegister(opWebRequest $request)
   {
-    $this->getUser()->logout();
     $member = $this->getUser()->setRegisterToken($request['token']);
 
     $this->forward404Unless($member && !$this->getUser()->isSNSMember() && $this->getUser()->isInvited());

--- a/lib/user/opSecurityUser.class.php
+++ b/lib/user/opSecurityUser.class.php
@@ -423,6 +423,8 @@ class opSecurityUser extends opAdaptableUser
 
   public function setRegisterToken($token)
   {
+    $this->logout();
+
     if ('MailAddress' === $this->getAuthAdapter()->getAuthModeName())
     {
       $mailTypes = array("pc_address", "pc_address_pre", "mobile_address", "mobile_address_pre");


### PR DESCRIPTION
revoke automatic login cookie before registration (fixes #3497 BP from #3416)
(cherry picked from commit 2cac338f0edd68b57d534413e54d4b4380237a83)

use empty string to clear member cache (fixes #3497 BP from #3416)
(cherry picked from commit eb5fe39f5619e7bcac973ca61bd32a94bfa28090)

revoke automatic login cookie on registration pages using register_token (fixes #3497 BP from #3416) 
(cherry picked from commit 8fbdf778cd6133103bbf08a261928893a8c2eb0d)
