### PR TITLE
fixed mail Return-Path header (BP for stable-3.6.x)

### DIFF
--- a/lib/util/opMailSend.class.php
+++ b/lib/util/opMailSend.class.php
@@ -215,11 +215,6 @@ class opMailSend
       ->setSubject(mb_encode_mimeheader($subject, 'iso-2022-jp'))
       ->setBodyText(mb_convert_encoding($body, 'JIS', 'UTF-8'), 'iso-2022-jp', Zend_Mime::ENCODING_7BIT);
 
-    if ($envelopeFrom = sfConfig::get('op_mail_envelope_from'))
-    {
-      $mailer->setReturnPath($envelopeFrom);
-    }
-
     $result = $mailer->send();
 
     Zend_Loader::registerAutoLoad('Zend_Loader', false);


### PR DESCRIPTION
Backport（バックポート） #3583: OpenPNE.ymlに設定したmail_envelope_fromがReturnPathに反映されない - OpenPNE 3 - OpenPNE Issue Tracking System
http://redmine.openpne.jp/issues/3583
