### PR TITLE
#3588のバグ対応

### DIFF
--- a/apps/pc_frontend/modules/community/actions/actions.class.php
+++ b/apps/pc_frontend/modules/community/actions/actions.class.php
@@ -56,7 +56,6 @@ class communityActions extends opCommunityAction
   {
     $this->forwardIf($request->isSmartphone(), 'community', 'smtEdit');
 
-    $this->enableImage = true;
     $result = parent::executeEdit($request);
 
     if ($this->community->isNew()) {

--- a/lib/action/opCommunityAction.class.php
+++ b/lib/action/opCommunityAction.class.php
@@ -91,9 +91,7 @@ abstract class opCommunityAction extends sfActions
 
     $this->communityForm       = new CommunityForm($this->community);
     $this->communityConfigForm = new CommunityConfigForm(array(), array('community' => $this->community));
-    $this->communityFileForm = isset($this->enableImage) && $this->enableImage ?
-      new CommunityFileForm(array(), array('community' => $this->community)) :
-      new CommunityFileForm();
+    $this->communityFileForm =  new CommunityFileForm(array(), array('community' => $this->community));
 
     if ($request->isMethod('post'))
     {


### PR DESCRIPTION
スマホから画像を設定してコミュニティを作成・編集した場合に空のコミュニティが作成される問題に対応しました。
https://redmine.openpne.jp/issues/3588
#138 と同じ問題に対するコミットなので、#138 も確認してください。
