### PR TITLE
(refs #831) fix text-decoration-toolbar display collapses.

### DIFF
--- a/web/css/main.css
+++ b/web/css/main.css
@@ -1291,6 +1291,7 @@ ol.activities li.activity .info {
  * toolbar of opWidgetFormRichTextareaOpenPNE
  *----------------------------------------------------------------------------*/
 div.parts table.mceToolbar {
+  table-layout: auto;
   width: auto;
 }
 


### PR DESCRIPTION
IE6, 7での文字装飾ツールバーの表示崩れ対応です。
https://redmine.openpne.jp/issues/831
