### PR TITLE
(refs #1606) fix imperfections of existence check of the model class

### DIFF
--- a/lib/task/opPluginInstallTask.class.php
+++ b/lib/task/opPluginInstallTask.class.php
@@ -60,7 +60,7 @@ EOF;
   {
     try
     {
-      if (class_exists('SnsConfigTable'))
+      if (class_exists('SnsConfigTable') && class_exists('BaseSnsConfigTable'))
       {
         return Doctrine_Manager::connection()
           ->import


### PR DESCRIPTION
opPluginInstallTask::execute() の中でモデルクラスのチェックが不完全な点を修正
https://redmine.openpne.jp/issues/1606
