### PR TITLE
fixed removal of trailing slash is not enough. (refs #1632)

### DIFF
--- a/lib/config/opApplicationConfiguration.class.php
+++ b/lib/config/opApplicationConfiguration.class.php
@@ -635,14 +635,11 @@ abstract class opApplicationConfiguration extends sfApplicationConfiguration
 
   protected function getAppScriptName($application, $env, $prefix, $isNoScriptName = false)
   {
+    $prefix = preg_replace('/(\/)$/', '', $prefix);
+
     if ($isNoScriptName)
     {
       return $prefix;
-    }
-
-    if ('/' === $prefix)
-    {
-      $prefix = '';
     }
 
     $name = $prefix.'/'.$application;


### PR DESCRIPTION
opApplicationConfiguration::getAppScriptName()で、prefixの末尾スラッシュ除去処理が不十分
への対応.
https://redmine.openpne.jp/issues/1632
