### PR TITLE
opMemberProfileSearchForm::addNameColumnQuery()内の変数名の誤りを修正

### DIFF
--- a/lib/form/searchForm/opMemberProfileSearchForm.class.php
+++ b/lib/form/searchForm/opMemberProfileSearchForm.class.php
@@ -101,7 +101,7 @@ class opMemberProfileSearchForm extends BaseForm
       {
         if (!empty($value))
         {
-          $query->andWhereLike('name', $values);
+          $query->andWhereLike('name', $value);
         }
       }
     }


### PR DESCRIPTION
$valuesという未定義変数を参照していますが$valueの誤りと思われます。
