### PR TITLE
MemberProfileTable::searchMemberIds()で参照先の変数名を修正

### DIFF
--- a/lib/model/doctrine/MemberProfileTable.class.php
+++ b/lib/model/doctrine/MemberProfileTable.class.php
@@ -174,7 +174,7 @@ class MemberProfileTable extends opAccessControlDoctrineTable
               continue;
             }
 
-            if ('year' !== $dateValue)
+            if ('year' !== $k)
             {
               $dateValue[$k] = sprintf('%02d', $dateValue[$k]);
             }


### PR DESCRIPTION
主にop_preset_birthdayの部分一致検索時に関係しますが、前後を見ればわかる通り$dateValueは$valueをコピーしたもので、year,month,dayをキーに持つ連想配列です。'year'とは===になりえません。
