### PR TITLE
#3220の修正

### DIFF
--- a/lib/user/opSecurityUser.class.php
+++ b/lib/user/opSecurityUser.class.php
@@ -277,8 +277,8 @@ class opSecurityUser extends opAdaptableUser
 
         $uri = '@member_setSid?next_uri='.$uri
              .'&is_remember_login='.(int)$this->getAuthAdapter()->getAuthForm()->getValue('is_remember_me')
-             .'&sid='.urlencode($item[0])
-             .'&ts='.urlencode($item[1]);
+             .'&sid='.rawurlencode($item[0])
+             .'&ts='.rawurlencode($item[1]);
       }
 
       $this->setCulture($this->getMember()->getConfig('language', sfConfig::get('sf_default_culture')));


### PR DESCRIPTION
#3220:opSecurityUser::login() で生成される member/setSid アクションへリダイレクトするために渡される個々のパラメータがURLエンコードされていない

https://redmine.openpne.jp/issues/3220
に対する修正です。

パラメータを個別にurlエンコードするようにしました。
