### PR TITLE
#2493 の修正

### DIFF
--- a/plugins/opSkinBasicPlugin/web/css/main.css
+++ b/plugins/opSkinBasicPlugin/web/css/main.css
@@ -982,7 +982,7 @@ div.operation ul.moreInfo li {
   width: 140px;
 }
 
-#pcAddressForm th, 
+#pcAddressForm th,
 #mobileAddressForm th {
   width: 175px;
 }


### PR DESCRIPTION
#2493: メールアドレス設定ページをMac Safari で閲覧した場合、レイアウトが2行で表示される

https://redmine.openpne.jp/issues/2493
についての修正です。

フィードバックに従い不要なスペースを削除しています。
