### PR TITLE
#2497 の修正

### DIFF
--- a/lib/widget/opWidgetFormRichTextarea.class.php
+++ b/lib/widget/opWidgetFormRichTextarea.class.php
@@ -65,9 +65,8 @@ class opWidgetFormRichTextarea extends sfWidgetFormTextarea
   }
 
   /**
-   * HTML特殊文字を実体参照で設定後に記号に変換されてしまう不具合修正のため、
-   * fixDoubleEscape() を呼ばないようにする
-   *
+   * not call the fixDoubleEscape() to not convert the HTML special characters that set in the entity reference
+   * 
    * @see sfWidget::escapeOnce()
    */
   static public function escapeOnce($value)


### PR DESCRIPTION
#2497: opWidgetFormRichTextareaを利用するフォームにおいてHTML特殊文字を実体参照で入力すると変換されてしまう

https://redmine.openpne.jp/issues/2497
についての修正

フィードバックに従いPHPDOCの説明を英語で書き直しました
