### PR TITLE
 コミュニティ作成不可カテゴリのコミュニティでコミュニティ副管理者が設定変更をおこなうとコミュニティカテゴリが空になる問題への対応

### DIFF
--- a/lib/form/doctrine/CommunityForm.class.php
+++ b/lib/form/doctrine/CommunityForm.class.php
@@ -36,10 +36,10 @@ class CommunityForm extends BaseCommunityForm
       {
         $choices[$category->id] = $category->name;
       }
-      $currentCategory = $this->object->CommunityCategory;
-      if (!is_null($currentCategory) && !isset($choices[$currentCategory->id]))
+      $currentCategoryId = $this->object->community_category_id;
+      if (!is_null($currentCategoryId) && !isset($choices[$currentCategoryId]))
       {
-        $choices[$currentCategory->id] = $currentCategory->name;
+        $choices[$currentCategoryId] = $this->object->CommunityCategory->name;
       }
       $this->setWidget('community_category_id', new sfWidgetFormChoice(array('choices' => array('' => '') + $choices)));
       $this->widgetSchema->setLabel('community_category_id', '%community% Category');


### PR DESCRIPTION
Bug ticket
https://redmine.openpne.jp/issues/3072
BP ticket
https://redmine.openpne.jp/issues/3682
