### PR TITLE
change the word ja into ja_JP for the integrity of yml in OpenPNE (fixes #3717, BP from #3502)

### DIFF
--- a/apps/api/config/settings.yml
+++ b/apps/api/config/settings.yml
@@ -90,4 +90,4 @@ all:
 #    logging_enabled:        true
 #
 #    # i18n
-    default_culture:        ja        # Default user culture
+    default_culture:        ja_JP        # Default user culture


### PR DESCRIPTION
bug ticket http://redmine.openpne.jp/issues/3502
BP ticket http://redmine.openpne.jp/issues/3717
