### PR TITLE
fix opDynamicAclRoute throws fatal error when using allow_empty option (fixes #3721, BP from #3507)

### DIFF
--- a/lib/routing/opDynamicAclRoute.class.php
+++ b/lib/routing/opDynamicAclRoute.class.php
@@ -29,16 +29,6 @@ class opDynamicAclRoute extends sfDoctrineRoute
   {
     $result = parent::getObject();
 
-    if (is_null($result))
-    {
-      return $result;
-    }
-
-    if (!$role = $this->getCurrentMemberId())
-    {
-      $role = 'alien';
-    }
-
     if ($result instanceof opAccessControlRecordInterface)
     {
       if (!$result->isAllowed($this->getCurrentMember(), $this->options['privilege']))

--- a/lib/routing/opDynamicAclRoute.class.php
+++ b/lib/routing/opDynamicAclRoute.class.php
@@ -29,6 +29,11 @@ class opDynamicAclRoute extends sfDoctrineRoute
   {
     $result = parent::getObject();
 
+    if (is_null($result))
+    {
+      return $result;
+    }
+
     if ($result instanceof opAccessControlRecordInterface)
     {
       if (!$result->isAllowed($this->getCurrentMember(), $this->options['privilege']))

--- a/lib/routing/opDynamicAclRoute.class.php
+++ b/lib/routing/opDynamicAclRoute.class.php
@@ -29,6 +29,16 @@ class opDynamicAclRoute extends sfDoctrineRoute
   {
     $result = parent::getObject();
 
+    if (is_null($result))
+    {
+      return $result;
+    }
+
+    if (!$role = $this->getCurrentMemberId())
+    {
+      $role = 'alien';
+    }
+
     if ($result instanceof opAccessControlRecordInterface)
     {
       if (!$result->isAllowed($this->getCurrentMember(), $this->options['privilege']))


### PR DESCRIPTION
bug tichet http://redmine.openpne.jp/issues/3507
BP tichet http://redmine.openpne.jp/issues/3721