### PR TITLE
fix MemberProfile::preSave() set empty string to value_datetime if valueis empty (fixes #3723, BP from #3543)

### DIFF
--- a/lib/model/doctrine/MemberProfile.class.php
+++ b/lib/model/doctrine/MemberProfile.class.php
@@ -147,7 +147,8 @@ class MemberProfile extends BaseMemberProfile implements opAccessControlRecordIn
     {
       $this->_set('value', $this->_get('value_datetime'));
     }
-    elseif ('date' === $this->getFormType() && isset($modified['value']) && $this->getProfile()->isPreset())
+    elseif ('date' === $this->getFormType() && $this->getProfile()->isPreset() &&
+            isset($modified['value']) && '' !== $modified['value'])
     {
       $this->_set('value_datetime', $this->_get('value'));
     }


### PR DESCRIPTION
bug ticket http://redmine.openpne.jp/issues/3543
BP ticket http://redmine.openpne.jp/issues/3723
