### PR TITLE
reject when the activity body is over 140 characters in activity/post.json (fixes #3728, BP from #3235)

### DIFF
--- a/apps/api/modules/activity/actions/actions.class.php
+++ b/apps/api/modules/activity/actions/actions.class.php
@@ -152,6 +152,7 @@ class activityActions extends opJsonApiActions
   {
     $body = (string)$request['body'];
     $this->forward400If('' === $body, 'body parameter not specified.');
+    $this->forward400If(mb_strlen($body) > 140, 'The body text is too long.');
 
     $memberId = $this->getUser()->getMemberId();
     $options = array();


### PR DESCRIPTION
bug ticket http://redmine.openpne.jp/issues/3235
BP ticket http://redmine.openpne.jp/issues/3728
