### PR TITLE
(refs #3734) added style 'overflow: hidden;' for 'row_membername' class in smt_main.css

### DIFF
--- a/web/css/smt_main.css
+++ b/web/css/smt_main.css
@@ -312,6 +312,7 @@ hr.white2 {
 .row_membername {
   height: 30px;
   line-height: 12px;
+  overflow: hidden;
 }
 
 .marginl0 {


### PR DESCRIPTION
https://redmine.openpne.jp/issues/3734
向けの修正です。

領域からあふれたものを非表示としています。
