### PR TITLE
isaosano fix opDynamicAclRoute throws fatal error when using allow_emptyoption (fixes #3722, BP form #3507)

### DIFF
--- a/lib/routing/opDynamicAclRoute.class.php
+++ b/lib/routing/opDynamicAclRoute.class.php
@@ -29,6 +29,11 @@ class opDynamicAclRoute extends sfDoctrineRoute
   {
     $result = parent::getObject();
 
+    if (is_null($result))
+    {
+      return $result;
+    }
+
     if ($result instanceof opAccessControlRecordInterface)
     {
       if (!$result->isAllowed($this->getCurrentMember(), $this->options['privilege']))


### PR DESCRIPTION
Bug ticket https://redmine.openpne.jp/issues/3507
BP ticket https://redmine.openpne.jp/issues/3722