### PR TITLE
[WIP] #3738: fileテーブルを参照するテーブル(activity_imageなど)の削除時に対応するfileレコードが削除されない

### DIFF
--- a/lib/model/doctrine/ActivityData.class.php
+++ b/lib/model/doctrine/ActivityData.class.php
@@ -44,4 +44,12 @@ class ActivityData extends BaseActivityData
 
     return $query->execute();
   }
+
+  public function preDelete($event)
+  {
+    foreach ($this->Images as $activityImage)
+    {
+      $activityImage->delete();
+    }
+  }
 }

--- a/lib/model/doctrine/ActivityImage.class.php
+++ b/lib/model/doctrine/ActivityImage.class.php
@@ -20,4 +20,8 @@
  */
 class ActivityImage extends BaseActivityImage
 {
+  public function preDelete($event)
+  {
+    $this->File->delete();
+  }
 }

--- a/lib/model/doctrine/Community.class.php
+++ b/lib/model/doctrine/Community.class.php
@@ -203,6 +203,14 @@ class Community extends BaseCommunity implements opAccessControlRecordInterface
     return 'everyone';
   }
 
+  public function preDelete($event)
+  {
+    if ($this->relatedExists('File'))
+    {
+      $this->File->delete();
+    }
+  }
+
   public function joinAllMembers($free = false)
   {
     $conn = Doctrine::getTable('Member')->getConnection();

--- a/test/bootstrap/database.php
+++ b/test/bootstrap/database.php
@@ -18,7 +18,7 @@ if (!isset($fixture))
 new sfDatabaseManager($configuration);
 
 $conn = opDoctrineQuery::getMasterConnectionDirect();
-if ($conn instanceof Doctrine_Connection_Mysql)
+if ('fix_wrong_categorized_community' === $fixture && $conn instanceof Doctrine_Connection_Mysql)
 {
   $conn->exec('SET FOREIGN_KEY_CHECKS = 0');
 }

--- a/test/fixtures/common/test_data.yml
+++ b/test/fixtures/common/test_data.yml
@@ -485,6 +485,10 @@ Community:
     name: "CommunityB"
   community_3:
     name: "CommunityC"
+    File:
+      name: dummy_image_community3
+      type: text/plain
+      FileBin: { bin: hogehoge }
   community_4:
     name: "CommunityD"
   community_5:

--- a/test/fixtures/common/test_data.yml
+++ b/test/fixtures/common/test_data.yml
@@ -949,6 +949,14 @@ ActivityData:
     body: "dummy8"
     template: "xxxx_template"
 
+ActivityImage:
+  activity1_image:
+    ActivityData: dummy_activity1
+    File:
+      name: dummy_image
+      type: text/plain
+      FileBin: { bin: dummy }
+
 SnsTerm:
   term_friend_pc_frontend:
     name: "friend"

--- a/test/unit/model/doctrine/ActivityDataTest.php
+++ b/test/unit/model/doctrine/ActivityDataTest.php
@@ -4,10 +4,30 @@ include_once dirname(__FILE__) . '/../../../bootstrap/unit.php';
 include_once dirname(__FILE__) . '/../../../bootstrap/database.php';
 sfContext::createInstance($configuration);
 
-$t = new lime_test(1, new lime_output_color());
+$conn = Doctrine_Core::getTable('ActivityData')->getConnection();
+
+$t = new lime_test(5);
 $activityData1 = Doctrine::getTable('ActivityData')->find(1);
+$activityImage = $activityData1->Images[0];
 
 //------------------------------------------------------------
 $t->diag('ActivityData');
 $t->diag('ActivityData::getPublicFlagCaption()');
 $t->is($activityData1->getPublicFlagCaption(), '全員に公開', '->getPublicFlagCaption() returns caption of public flag');
+
+//------------------------------------------------------------
+$t->diag('ActivityData: Cascading Delete');
+$conn->beginTransaction();
+
+$activityDataId = $activityData1->id;
+$activityImageId = $activityImage->id;
+$fileId = $activityImage->file_id;
+
+$activityData1->delete($conn);
+
+$t->ok(!Doctrine_Core::getTable('ActivityData')->find($activityDataId), 'activity_data is deleted.');
+$t->ok(!Doctrine_Core::getTable('ActivityImage')->find($activityImageId), 'activity_image is deleted.');
+$t->ok(!Doctrine_Core::getTable('File')->find($fileId), 'file is deleted.');
+$t->ok(!Doctrine_Core::getTable('FileBin')->find($fileId), 'file_bin is deleted.');
+
+$conn->rollback();

--- a/test/unit/model/doctrine/CommunityTest.php
+++ b/test/unit/model/doctrine/CommunityTest.php
@@ -4,10 +4,11 @@ include_once dirname(__FILE__) . '/../../../bootstrap/unit.php';
 include_once dirname(__FILE__) . '/../../../bootstrap/database.php';
 sfContext::createInstance($configuration);
 
-$t = new lime_test(36, new lime_output_color());
+$t = new lime_test(39);
 
 $community1 = Doctrine::getTable('Community')->findOneByName('CommunityA');
 $community2 = Doctrine::getTable('Community')->findOneByName('CommunityB');
+$community3 = Doctrine::getTable('Community')->findOneByName('CommunityC');
 $community4 = Doctrine::getTable('Community')->findOneByName('CommunityD');
 $community5 = Doctrine::getTable('Community')->findOneByName('CommunityE');
 
@@ -109,3 +110,16 @@ $t->is($community1->generateRoleId(Doctrine::getTable('Member')->find(1)), 'admi
 $t->is($community1->generateRoleId(Doctrine::getTable('Member')->find(2)), 'member', 'generateRoleId() returns "member"');
 $t->is($community1->generateRoleId(Doctrine::getTable('Member')->find(3)), 'everyone', 'generateRoleId() returns "everyone"');
 $t->is($community5->generateRoleId(Doctrine::getTable('Member')->find(2)), 'sub_admin', 'generateRoleId() returns "sub_admin"');
+
+//------------------------------------------------------------
+$t->diag('Community: Cascading Delete');
+$conn->beginTransaction();
+
+$fileId = $community3->file_id;
+$community3->delete($conn);
+
+$t->ok(!Doctrine_Core::getTable('Community')->find($community3->id), 'community is deleted.');
+$t->ok(!Doctrine_Core::getTable('File')->find($fileId), 'file is deleted.');
+$t->ok(!Doctrine_Core::getTable('FileBin')->find($fileId), 'file_bin is deleted.');
+
+$conn->rollback();


### PR DESCRIPTION
#### 親チケット

Bug (バグ) #3738: fileテーブルを参照するテーブル(activity_imageなど)の削除時に対応するfileレコードが削除されない
https://redmine.openpne.jp/issues/3738

#### 子チケット

Bug (バグ) #3752: アクティビティを削除しても添付された画像がDBから削除されない
https://redmine.openpne.jp/issues/3752

Bug (バグ) #3753: コミュニティ画像が設定されたコミュニティを削除しても画像がDBから削除されない
https://redmine.openpne.jp/issues/3753

#### 進捗
 - [x] activity_image
 - [ ] banner_image
 - [x] community
 - [ ] oauth_consumer