### PR TITLE
clear MemberConfig caches on every request by opBrowser (fixes #3852)

### DIFF
--- a/lib/util/opBrowser.class.php
+++ b/lib/util/opBrowser.class.php
@@ -16,6 +16,14 @@
  */
 class opBrowser extends sfBrowser
 {
+  protected function doCall()
+  {
+    // Clear internal MemberConfig cache
+    Doctrine_Core::getTable('MemberConfig')->results = array();
+
+    parent::doCall();
+  }
+
   /**
    * @see sfBrowserBase::doClick()
    * @see http://trac.symfony-project.org/ticket/5748


### PR DESCRIPTION
Bug (バグ) #3852: 機能テスト実行時にopBrowserによる各リクエスト間でMemberConfigのキャッシュが意図せず引き継がれてしまう
https://redmine.openpne.jp/issues/3852

上記のバグチケットに対する修正です。