### PR TITLE
[sfImageHandlerPlugin] sfImageGeneratorImageTransform::doResize() causes an error when using ImageMagick (fixes #3859, BP from #3195)

### DIFF
--- a/lib/plugins/sfImageHandlerPlugin/lib/image/generator/sfImageGeneratorImageTransform.php
+++ b/lib/plugins/sfImageHandlerPlugin/lib/image/generator/sfImageGeneratorImageTransform.php
@@ -91,8 +91,9 @@ abstract class sfImageGeneratorImageTransform extends sfImageGenerator
       {
         throw new sfException($result->getMessage());
       }
-      $this->transform->load($tmpoutputfilename);
-      unlink($tmpoutputfilename);     
+      rename($tmpoutputfilename, $tmpfilename);
+      $this->transform->load($tmpfilename);
+      $this->transform->fit($this->width, $this->height);
     }
 
     if ($this->width && $this->height)


### PR DESCRIPTION
[Bug ticket]
http://redmine.openpne.jp/issues/3195

[BP ticket]
http://redmine.openpne.jp/issues/3859
