### PR TITLE
(refs #3868, BP from #3734) added style 'overflow: hidden;' for 'row_membername' class in smt_main.css

### DIFF
--- a/web/css/smt_main.css
+++ b/web/css/smt_main.css
@@ -312,6 +312,7 @@ hr.white2 {
 .row_membername {
   height: 30px;
   line-height: 12px;
+  overflow: hidden;
 }
 
 .marginl0 {


### PR DESCRIPTION
[Bug ticket]
http://redmine.openpne.jp/issues/3734
[BP ticket]
http://redmine.openpne.jp/issues/3868