### PR TITLE
(fixes #3640, BP from #2494) added nickname to profile page

### DIFF
--- a/apps/mobile_frontend/modules/member/templates/profileSuccess.php
+++ b/apps/mobile_frontend/modules/member/templates/profileSuccess.php
@@ -33,6 +33,9 @@
 <td valign="top">
 <?php
 $list = array();
+
+$list[__('%Nickname%')] = $member->getName();
+
 if ($member->getAge(true))
 {
   $ageValue = __('%1% years old', array('%1%' => $member->getAge()));

--- a/apps/pc_frontend/modules/member/templates/_profileListBox.php
+++ b/apps/pc_frontend/modules/member/templates/_profileListBox.php
@@ -3,6 +3,9 @@
 $culture = sfCultureInfo::getInstance($sf_user->getCulture());
 
 $list = array();
+
+$list[__('%Nickname%')] = $member->getName();
+
 if ($member->getAge(true) !== false)
 {
   $ageValue = __('%1% years old', array('%1%' => $member->getAge()));

--- a/plugins/opSkinBasicPlugin/web/css/main.css
+++ b/plugins/opSkinBasicPlugin/web/css/main.css
@@ -1053,7 +1053,9 @@ div.operation ul.moreInfo li {
   width: 83px;
   background-color: #FFFFFF;
 }
-
+#profile th {
+  width: 89px;
+}
 .listBox th, .listBox td {
   padding: 5px;
 }


### PR DESCRIPTION
Backport (バックポート) #3640: 「プロフィール編集」で編集できるニックネームが「プロフィール確認」のテーブルに表示されない
https://redmine.openpne.jp/issues/3640