### PR TITLE
(fixes #3642, BP from #2503) fixed coding standard rule considering whitespace

### DIFF
--- a/data/CodingStandard/OpenPNE3/Sniffs/WhiteSpace/ControlSignatureSniff.php
+++ b/data/CodingStandard/OpenPNE3/Sniffs/WhiteSpace/ControlSignatureSniff.php
@@ -19,14 +19,14 @@ class OpenPNE3_Sniffs_WhiteSpace_ControlSignatureSniff extends PHP_CodeSniffer_S
   protected function getPatterns()
   {
     return array(
-       'tryEOL{EOL...}EOLcatch (...)EOL{EOL',
-       'doEOL{EOL...}EOLwhile (...);EOL',
-       'while (...)EOL{EOL',
-       'for (...)EOL{EOL',
-       'if (...)EOL{EOL',
-       'foreach (...)EOL{EOL',
-       '}EOLelseif (...)EOL{EOL',
-       '}EOLelseEOL{EOL',
+       'tryEOL *{EOL...}EOL *catch (...)EOL *{EOL',
+       'doEOL *{EOL...}EOL *while (...);EOL',
+       'while (...)EOL *{EOL',
+       'for (...)EOL *{EOL',
+       'if (...)EOL *{EOL',
+       'foreach (...)EOL *{EOL',
+       '} *EOLelseif (...)EOL *{EOL',
+       '} *EOLelseEOL *{EOL',
     );
   }
 }


### PR DESCRIPTION
Backport (バックポート) #3642: コーディング規約チェックのルールにおいて制御構造のブロックで空白が考慮されていない
https://redmine.openpne.jp/issues/3642