### PR TITLE
control the range for setting age_public_flag (fixes #3493, BP from #3453)

### DIFF
--- a/lib/form/MemberConfigForm/MemberConfigPublicFlagForm.class.php
+++ b/lib/form/MemberConfigForm/MemberConfigPublicFlagForm.class.php
@@ -28,7 +28,7 @@ class MemberConfigPublicFlagForm extends MemberConfigForm
       unset($this['profile_page_public_flag']);
     }
 
-    if (!opConfig::get('is_allow_web_public_flag_age'))
+    if (opConfig::get('is_allow_web_public_flag_age'))
     {
       $widget = $this->widgetSchema['age_public_flag'];
 
@@ -37,6 +37,10 @@ class MemberConfigPublicFlagForm extends MemberConfigForm
       $widget->setOption('choices', $choices);
 
       $this->validatorSchema['age_public_flag']->setOption('choices', array_keys($choices));
+    }
+    else
+    {
+      unset($this['age_public_flag']);
     }
   }
 }

--- a/lib/form/doctrine/MemberConfigForm.class.php
+++ b/lib/form/doctrine/MemberConfigForm.class.php
@@ -48,7 +48,12 @@ class MemberConfigForm extends BaseForm
   public function generateConfigWidgets()
   {
     foreach ($this->memberConfigSettings as $key => $value) {
-      if ($this->isNew && $value['IsRegist'] || !$this->isNew && $value['IsConfig']) {
+      if($value['Name'] == "age_public_flag" && !opConfig::get('is_allow_web_public_flag_age'))
+      {
+        $value['IsRegist'] = false;
+      }
+      if ($this->isNew && $value['IsRegist'] || !$this->isNew && $value['IsConfig'])
+      {
         $this->setMemberConfigWidget($key);
       }
     }


### PR DESCRIPTION
Backport (バックポート) #3493: 管理画面で「Web 全体への年齢公開許可設定」を「メンバーの設定を許可しない」に設定しても新規登録時には選択できてしまう
https://redmine.openpne.jp/issues/3493
