### PR TITLE
add openpne.baseUrl for client-side rendering (fixes #3989, BP from #3365)

### DIFF
--- a/apps/pc_frontend/templates/_layout.php
+++ b/apps/pc_frontend/templates/_layout.php
@@ -19,6 +19,7 @@ use_javascript('op_notify.js');
 $jsonData = array(
   'apiKey' => $sf_user->getMemberApiKey(),
   'apiBase' => app_url_for('api', 'homepage'),
+  'baseUrl' => $sf_request->getRelativeUrlRoot().'/',
 );
 
 $json = defined('JSON_PRETTY_PRINT') ? json_encode($jsonData, JSON_PRETTY_PRINT) : json_encode($jsonData);

--- a/apps/pc_frontend/templates/smtLayoutGroup.php
+++ b/apps/pc_frontend/templates/smtLayoutGroup.php
@@ -16,6 +16,7 @@
 $jsonData = array(
   'apiKey' => $sf_user->getMemberApiKey(),
   'apiBase' => app_url_for('api', 'homepage'),
+  'baseUrl' => $sf_request->getRelativeUrlRoot().'/',
 );
 
 $json = defined('JSON_PRETTY_PRINT') ? json_encode($jsonData, JSON_PRETTY_PRINT) : json_encode($jsonData);

--- a/apps/pc_frontend/templates/smtLayoutHome.php
+++ b/apps/pc_frontend/templates/smtLayoutHome.php
@@ -16,6 +16,7 @@
 $jsonData = array(
   'apiKey' => $sf_user->getMemberApiKey(),
   'apiBase' => app_url_for('api', 'homepage'),
+  'baseUrl' => $sf_request->getRelativeUrlRoot().'/',
 );
 
 $json = defined('JSON_PRETTY_PRINT') ? json_encode($jsonData, JSON_PRETTY_PRINT) : json_encode($jsonData);

--- a/apps/pc_frontend/templates/smtLayoutMember.php
+++ b/apps/pc_frontend/templates/smtLayoutMember.php
@@ -16,6 +16,7 @@
 $jsonData = array(
   'apiKey' => $sf_user->getMemberApiKey(),
   'apiBase' => app_url_for('api', 'homepage'),
+  'baseUrl' => $sf_request->getRelativeUrlRoot().'/',
 );
 
 $json = defined('JSON_PRETTY_PRINT') ? json_encode($jsonData, JSON_PRETTY_PRINT) : json_encode($jsonData);

--- a/apps/pc_frontend/templates/smtLayoutSns.php
+++ b/apps/pc_frontend/templates/smtLayoutSns.php
@@ -16,6 +16,7 @@
 $jsonData = array(
   'apiKey' => opToolkit::isSecurePage() ? $sf_user->getMemberApiKey() : '',
   'apiBase' => app_url_for('api', 'homepage'),
+  'baseUrl' => $sf_request->getRelativeUrlRoot().'/',
 );
 
 $json = defined('JSON_PRETTY_PRINT') ? json_encode($jsonData, JSON_PRETTY_PRINT) : json_encode($jsonData);


### PR DESCRIPTION
Backport (バックポート) #3989: OpenPNEが設置されているURLをJavaScriptコードから取得できるようにする
https://redmine.openpne.jp/issues/3989