### PR TITLE
メールアドレス変更に関する複数の修正 (fixes #3077, #4012)

### DIFF
--- a/apps/pc_frontend/modules/member/templates/configCompleteSuccess.php
+++ b/apps/pc_frontend/modules/member/templates/configCompleteSuccess.php
@@ -1,7 +1,15 @@
+<?php slot('firstRow') ?>
+<tr>
+  <th><?php echo __($settings['Caption']) ?></th>
+  <td><?php echo $newValue ?></td>
+</tr>
+<?php end_slot() ?>
+
 <?php
 $options = array(
   'title' => __('Change Settings'),
   'url' => url_for(sprintf('member/configComplete?token=%s&id=%s&type=%s', $sf_params->get('token'), $sf_params->get('id'), $sf_params->get('type'))),
+  'firstRow' => get_slot('firstRow'),
   'button' => __('Send'),
 );
 op_include_form('formConfigComplete', $form, $options);

--- a/lib/action/opMemberAction.class.php
+++ b/lib/action/opMemberAction.class.php
@@ -286,11 +286,11 @@ abstract class opMemberAction extends sfActions
 
     $memberId = $request->getParameter('id');
 
-    $memberConfig = Doctrine::getTable('MemberConfig')->retrieveByNameAndMemberId($type.'_token', $memberId);
-    $this->forward404Unless($memberConfig);
-    $this->forward404Unless($request->getParameter('token') === $memberConfig->getValue());
+    $token = Doctrine::getTable('MemberConfig')->retrieveByNameAndMemberId($type.'_token', $memberId);
+    $this->forward404Unless($token);
+    $this->forward404Unless($request->getParameter('token') === $token->getValue());
 
-    $option = array('member' => $memberConfig->getMember());
+    $option = array('member' => $token->getMember());
     $this->form = new opPasswordForm(array(), $option);
 
     if ($request->isMethod('post'))
@@ -312,7 +312,6 @@ abstract class opMemberAction extends sfActions
         $config->save();
 
         $pre->delete();
-        $token = Doctrine::getTable('MemberConfig')->retrieveByNameAndMemberId($type.'_token', $memberId);
         $token->delete();
 
         $this->redirect('@homepage');

--- a/lib/action/opMemberAction.class.php
+++ b/lib/action/opMemberAction.class.php
@@ -309,12 +309,11 @@ abstract class opMemberAction extends sfActions
         }
         $config->setValue($pre->getValue());
 
-        if ($config->save())
-        {
-          $pre->delete();
-          $token = Doctrine::getTable('MemberConfig')->retrieveByNameAndMemberId($type.'_token', $memberId);
-          $token->delete();
-        }
+        $config->save();
+
+        $pre->delete();
+        $token = Doctrine::getTable('MemberConfig')->retrieveByNameAndMemberId($type.'_token', $memberId);
+        $token->delete();
 
         $this->redirect('@homepage');
       }

--- a/lib/action/opMemberAction.class.php
+++ b/lib/action/opMemberAction.class.php
@@ -309,6 +309,13 @@ abstract class opMemberAction extends sfActions
         }
         $config->setValue($pre->getValue());
 
+        if (!$config->checkUniqueness())
+        {
+          $this->getUser()->setFlash('error', 'The inputted value is already exist.');
+
+          return sfView::SUCCESS;
+        }
+
         $config->save();
 
         $pre->delete();

--- a/lib/action/opMemberAction.class.php
+++ b/lib/action/opMemberAction.class.php
@@ -290,6 +290,12 @@ abstract class opMemberAction extends sfActions
     $this->forward404Unless($token);
     $this->forward404Unless($request->getParameter('token') === $token->getValue());
 
+    $pre = Doctrine::getTable('MemberConfig')->retrieveByNameAndMemberId($type.'_pre', $memberId);
+
+    $settings = sfConfig::get('openpne_member_config');
+    $this->settings = $settings[$type];
+    $this->newValue = $pre->getValue();
+
     $option = array('member' => $token->getMember());
     $this->form = new opPasswordForm(array(), $option);
 
@@ -299,7 +305,6 @@ abstract class opMemberAction extends sfActions
       if ($this->form->isValid())
       {
         $config = Doctrine::getTable('MemberConfig')->retrieveByNameAndMemberId($type, $memberId);
-        $pre = Doctrine::getTable('MemberConfig')->retrieveByNameAndMemberId($type.'_pre', $memberId);
 
         if (!$config)
         {

--- a/lib/model/doctrine/MemberConfig.class.php
+++ b/lib/model/doctrine/MemberConfig.class.php
@@ -117,6 +117,19 @@ class MemberConfig extends BaseMemberConfig implements opAccessControlRecordInte
     return $config[$this->getName()];
   }
 
+  public function checkUniqueness()
+  {
+    $settings = $this->getSetting();
+    if (!isset($settings['IsUnique']) || !$settings['IsUnique'])
+    {
+      return true;
+    }
+
+    $duplicate = $this->getTable()->retrieveByNameAndValue($this->name, $this->value);
+
+    return !$duplicate || $duplicate->member_id === $this->member_id;
+  }
+
   public function generateRoleId(Member $member)
   {
     if ($this->Member->id === $member->id)

--- a/test/functional/pc_frontend/memberConfigConfirmTest.php
+++ b/test/functional/pc_frontend/memberConfigConfirmTest.php
@@ -1,0 +1,51 @@
+<?php
+
+require_once __DIR__.'/../../bootstrap/functional.php';
+
+opMailSend::initialize();
+Zend_Mail::setDefaultTransport(new opZendMailTransportMock());
+
+Doctrine_Core::getTable('SnsConfig')->set('is_use_captcha', '0');
+
+$member1 = Doctrine_Core::getTable('Member')->find(1);
+
+$tester = new opTestFunctional(new opBrowser(), new lime_test(), array(
+  'doctrine' => 'sfTesterDoctrine',
+));
+
+$tester->info('/member/config: Email Confirmation Test');
+
+$tester
+  ->login('sns@example.com', 'password')
+
+  ->get('/member/config?category=pcAddress')
+  ->click('送信', array(
+    'member_config' => array(
+      'pc_address' => 'sns+new@example.com',
+      'pc_address_confirm' => 'sns+new@example.com',
+    ),
+  ))
+
+  ->with('doctrine')->begin()
+    ->check('MemberConfig', array('member_id' => 1, 'name' => 'pc_address', 'value' => 'sns@example.com'), 1)
+    ->check('MemberConfig', array('member_id' => 1, 'name' => 'pc_address_pre', 'value' => 'sns+new@example.com'), 1)
+    ->check('MemberConfig', array('member_id' => 1, 'name' => 'pc_address_token'), 1)
+  ->end()
+;
+
+$confirmToken = $member1->getConfig('pc_address_token');
+
+$tester
+  ->get('/member/configComplete', array('id' => 1, 'type' => 'pc_address', 'token' => $confirmToken))
+  ->click('送信', array(
+    'password' => array(
+      'password' => 'password',
+    ),
+  ))
+
+  ->with('doctrine')->begin()
+    ->check('MemberConfig', array('member_id' => 1, 'name' => 'pc_address', 'value' => 'sns+new@example.com'), 1)
+    ->check('MemberConfig', array('member_id' => 1, 'name' => 'pc_address_pre'), false)
+    ->check('MemberConfig', array('member_id' => 1, 'name' => 'pc_address_token'), false)
+  ->end()
+;

--- a/test/functional/pc_frontend/memberConfigConfirmTest.php
+++ b/test/functional/pc_frontend/memberConfigConfirmTest.php
@@ -38,6 +38,11 @@ $confirmToken = $member1->getConfig('pc_address_token');
 
 $tester
   ->get('/member/configComplete', array('id' => 1, 'type' => 'pc_address', 'token' => $confirmToken))
+  ->with('response')->begin()
+    ->checkElement('#formConfigComplete tr:nth-child(1) th', 'PCメールアドレス')
+    ->checkElement('#formConfigComplete tr:nth-child(1) td', 'sns+new@example.com')
+  ->end()
+
   ->click('送信', array(
     'password' => array(
       'password' => 'password',
@@ -98,6 +103,11 @@ $member2->setConfig('pc_address', 'sns+dupe@example.com');
 
 $tester
   ->get('/member/configComplete', array('id' => 1, 'type' => 'pc_address', 'token' => $confirmToken))
+  ->with('response')->begin()
+    ->checkElement('#formConfigComplete tr:nth-child(1) th', 'PCメールアドレス')
+    ->checkElement('#formConfigComplete tr:nth-child(1) td', 'sns+dupe@example.com')
+  ->end()
+
   ->click('送信', array(
     'password' => array(
       'password' => 'password',

--- a/test/functional/pc_frontend/memberConfigConfirmTest.php
+++ b/test/functional/pc_frontend/memberConfigConfirmTest.php
@@ -8,6 +8,7 @@ Zend_Mail::setDefaultTransport(new opZendMailTransportMock());
 Doctrine_Core::getTable('SnsConfig')->set('is_use_captcha', '0');
 
 $member1 = Doctrine_Core::getTable('Member')->find(1);
+$member2 = Doctrine_Core::getTable('Member')->find(2);
 
 $tester = new opTestFunctional(new opBrowser(), new lime_test(), array(
   'doctrine' => 'sfTesterDoctrine',
@@ -48,4 +49,60 @@ $tester
     ->check('MemberConfig', array('member_id' => 1, 'name' => 'pc_address_pre'), false)
     ->check('MemberConfig', array('member_id' => 1, 'name' => 'pc_address_token'), false)
   ->end()
+;
+
+$tester->info('/member/config: Email Confirmation + IsUnique Test (Error while member/config action)');
+
+$member1->setConfig('pc_address', 'sns@example.com');
+$member2->setConfig('pc_address', 'sns+dupe@example.com');
+
+$tester
+  ->login('sns@example.com', 'password')
+
+  ->get('/member/config?category=pcAddress')
+  ->click('送信', array(
+    'member_config' => array(
+      'pc_address' => 'sns+dupe@example.com',
+      'pc_address_confirm' => 'sns+dupe@example.com',
+    ),
+  ))
+
+  ->with('form')->hasError()
+;
+
+$tester->info('/member/config: Email Confirmation + IsUnique Test (Error while member/configComplete action)');
+
+$member1->setConfig('pc_address', 'sns@example.com');
+$member2->setConfig('pc_address', 'sns2@example.com');
+
+$tester
+  ->login('sns@example.com', 'password')
+
+  ->get('/member/config?category=pcAddress')
+  ->click('送信', array(
+    'member_config' => array(
+      'pc_address' => 'sns+dupe@example.com',
+      'pc_address_confirm' => 'sns+dupe@example.com',
+    ),
+  ))
+
+  ->with('doctrine')->begin()
+    ->check('MemberConfig', array('member_id' => 1, 'name' => 'pc_address', 'value' => 'sns@example.com'), 1)
+    ->check('MemberConfig', array('member_id' => 1, 'name' => 'pc_address_pre', 'value' => 'sns+dupe@example.com'), 1)
+    ->check('MemberConfig', array('member_id' => 1, 'name' => 'pc_address_token'), 1)
+  ->end()
+;
+
+$confirmToken = $member1->getConfig('pc_address_token');
+$member2->setConfig('pc_address', 'sns+dupe@example.com');
+
+$tester
+  ->get('/member/configComplete', array('id' => 1, 'type' => 'pc_address', 'token' => $confirmToken))
+  ->click('送信', array(
+    'password' => array(
+      'password' => 'password',
+    ),
+  ))
+
+  ->with('user')->isFlash('error', 'The inputted value is already exist.')
 ;


### PR DESCRIPTION
Bug (バグ) #3077: メールアドレス変更処理が完了しても、仮登録用のデータ (`***_pre`, `***_token`) が MemberConfig に残ってしまい、削除されない
https://redmine.openpne.jp/issues/3077

Bug (バグ) #4012: メールアドレス設定から意図的に他のメンバーと同じメールアドレスを設定できる
https://redmine.openpne.jp/issues/4012

上記のバグチケットに対する修正を含んでいます。
