### PR TITLE
don't save captcha value to member_config (fixes #4013)

### DIFF
--- a/lib/form/MemberConfigForm/MemberConfigMobileAddressForm.class.php
+++ b/lib/form/MemberConfigForm/MemberConfigMobileAddressForm.class.php
@@ -31,6 +31,11 @@ class MemberConfigMobileAddressForm extends MemberConfigForm
 
   public function saveConfig($name, $value)
   {
+    if ($name === 'captcha')
+    {
+      return;
+    }
+
     if ($name === 'mobile_address')
     {
       $this->savePreConfig($name, $value);

--- a/lib/form/MemberConfigForm/MemberConfigPcAddressForm.class.php
+++ b/lib/form/MemberConfigForm/MemberConfigPcAddressForm.class.php
@@ -31,6 +31,11 @@ class MemberConfigPcAddressForm extends MemberConfigForm
 
   public function saveConfig($name, $value)
   {
+    if ($name === 'captcha')
+    {
+      return;
+    }
+
     if ($name === 'pc_address')
     {
       $this->savePreConfig($name, $value);


### PR DESCRIPTION
Bug (バグ) #4013: メールアドレス変更を行うと member_config に name='captcha' のレコードが追加される
https://redmine.openpne.jp/issues/4013