### PR TITLE
(fixed #4030, BP from #3966) Internet Explorer 11 にてダウンロード時に日本語ファイル名が文字化けする

### DIFF
--- a/lib/util/opToolkit.class.php
+++ b/lib/util/opToolkit.class.php
@@ -338,13 +338,14 @@ class opToolkit
  */
   static public function fileDownload($original_filename, $bin)
   {
+    $filename = $original_filename;
     if (strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE') !== false) {
-      $original_filename = mb_convert_encoding($original_filename, 'SJIS', 'UTF-8');
+      $filename = mb_convert_encoding($filename, 'SJIS', 'UTF-8');
     }
-    $original_filename = str_replace(array("\r", "\n"), '', $original_filename);
+    $filename = str_replace(array("\r", "\n"), '', $filename);
 
     $encoded_filename = rawurlencode($original_filename);
-    header('Content-Disposition: attachment; filename="' . $encoded_filename . '"; filename*=utf-8\'\'' . $encoded_filename);
+    header('Content-Disposition: attachment; filename="' . $filename . '"; filename*=utf-8\'\'' . $encoded_filename);
 
     header('Content-Length: '.strlen($bin));
     header('Content-Type: application/octet-stream');

--- a/lib/util/opToolkit.class.php
+++ b/lib/util/opToolkit.class.php
@@ -339,15 +339,9 @@ class opToolkit
   static public function fileDownload($original_filename, $bin)
   {
     $original_filename = str_replace(array("\r", "\n"), '', $original_filename);
-
-    $filename = $original_filename;
-    if (strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE') !== false) {
-      $filename = mb_convert_encoding($filename, 'SJIS', 'UTF-8');
-    }
-
     $encoded_filename = rawurlencode($original_filename);
-    header('Content-Disposition: attachment; filename="' . $filename . '"; filename*=utf-8\'\'' . $encoded_filename);
 
+    header('Content-Disposition: attachment; filename="' . $encoded_filename . '"; filename*=utf-8\'\'' . $encoded_filename);
     header('Content-Length: '.strlen($bin));
     header('Content-Type: application/octet-stream');
 

--- a/lib/util/opToolkit.class.php
+++ b/lib/util/opToolkit.class.php
@@ -338,11 +338,12 @@ class opToolkit
  */
   static public function fileDownload($original_filename, $bin)
   {
+    $original_filename = str_replace(array("\r", "\n"), '', $original_filename);
+
     $filename = $original_filename;
     if (strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE') !== false) {
       $filename = mb_convert_encoding($filename, 'SJIS', 'UTF-8');
     }
-    $filename = str_replace(array("\r", "\n"), '', $filename);
 
     $encoded_filename = rawurlencode($original_filename);
     header('Content-Disposition: attachment; filename="' . $filename . '"; filename*=utf-8\'\'' . $encoded_filename);

--- a/lib/util/opToolkit.class.php
+++ b/lib/util/opToolkit.class.php
@@ -343,7 +343,9 @@ class opToolkit
     }
     $original_filename = str_replace(array("\r", "\n"), '', $original_filename);
 
-    header('Content-Disposition: attachment; filename="'.$original_filename.'"');
+    $encoded_filename = rawurlencode($original_filename);
+    header('Content-Disposition: attachment; filename="' . $encoded_filename . '"; filename*=utf-8\'\'' . $encoded_filename);
+
     header('Content-Length: '.strlen($bin));
     header('Content-Type: application/octet-stream');
 


### PR DESCRIPTION
bug ticket http://redmine.openpne.jp/issues/3966
BP ticket http://redmine.openpne.jp/issues/4030
