### PR TITLE
retrieve only cached package info for opPlugin::__construct() (fixes #4038, BP from #3352)

### DIFF
--- a/lib/plugin/opPlugin.class.php
+++ b/lib/plugin/opPlugin.class.php
@@ -46,8 +46,10 @@ class opPlugin
     }
     else
     {
-      $manager = new opPluginManager($dispatcher);
-      $package = $manager->getEnvironment()->getRegistry()->getPackage($pluginName, opPluginManager::getDefaultPluginChannelServerName());
+      $environment = opPluginManager::createPearEnvironment($dispatcher);
+      $channel = opPluginManager::getDefaultPluginChannelServerName();
+
+      $package = $environment->getRegistry()->getPackage($pluginName, $channel);
       if ($package)
       {
         $this->version = $package->getVersion();

--- a/lib/plugin/opPluginManager.class.php
+++ b/lib/plugin/opPluginManager.class.php
@@ -29,17 +29,7 @@ class opPluginManager extends sfSymfonyPluginManager
   {
     if (!$environment)
     {
-      $tz = @date_default_timezone_get();
-
-      $environment = new sfPearEnvironment($dispatcher, array(
-        'plugin_dir'            => sfConfig::get('sf_plugins_dir'),
-        'cache_dir'             => sfConfig::get('sf_cache_dir').'/.pear',
-        'web_dir'               => sfConfig::get('sf_web_dir'),
-        'rest_base_class'       => 'opPearRest',
-        'downloader_base_class' => 'opPluginDownloader',
-      ));
-
-      date_default_timezone_set($tz);
+      $environment = self::createPearEnvironment($dispatcher);
 
       $this->channel = $channel;
       if (!$this->channel)
@@ -136,6 +126,23 @@ class opPluginManager extends sfSymfonyPluginManager
         $filesystem->remove($targetDir);
       }
     }
+  }
+
+  public static function createPearEnvironment(sfEventDispatcher $dispatcher)
+  {
+    $tz = @date_default_timezone_get();
+
+    $environment = new sfPearEnvironment($dispatcher, array(
+      'plugin_dir'            => sfConfig::get('sf_plugins_dir'),
+      'cache_dir'             => sfConfig::get('sf_cache_dir').'/.pear',
+      'web_dir'               => sfConfig::get('sf_web_dir'),
+      'rest_base_class'       => 'opPearRest',
+      'downloader_base_class' => 'opPluginDownloader',
+    ));
+
+    date_default_timezone_set($tz);
+
+    return $environment;
   }
 
   public static function getPluginActivationList()


### PR DESCRIPTION
Bug (バグ) #3352: プラグインチャンネルサーバに接続できない場合に管理画面のプラグインリスト画面が表示できない場合がある
https://redmine.openpne.jp/issues/3352

Backport（バックポート） #4038: プラグインチャンネルサーバに接続できない場合に管理画面のプラグインリスト画面が表示できない場合がある
https://redmine.openpne.jp/issues/4038