### PR TITLE
(fixed #4055) 通知センターからアクセスする際のURLに openpne.baseUrl を利用するよう修正

### DIFF
--- a/web/js/jquery.notify.js
+++ b/web/js/jquery.notify.js
@@ -5,7 +5,8 @@
     }, settings);
 
     return this.each(function(){
-      var linkUrl = $(this).attr('data-location-url');
+      var linkUrl = openpne.baseUrl + $(this).attr('data-location-url');
+      linkUrl = linkUrl.replace(/\/\//g, "/");
       var notifyId = $(this).attr('data-notify-id');
       $(this).click(function(){
         if ( false == settings.isDisableRead )


### PR DESCRIPTION
https://redmine.openpne.jp/issues/4055