### PR TITLE
(fixed #2909) メール通知テンプレート設定のタイトルの文字数チェックを行うように変更

### DIFF
--- a/lib/form/doctrine/NotificationMailTranslationForm.class.php
+++ b/lib/form/doctrine/NotificationMailTranslationForm.class.php
@@ -13,7 +13,7 @@ class NotificationMailTranslationForm extends BaseNotificationMailTranslationFor
   {
     unset($this['lang'], $this['id']);
 
-    $this->setValidator('title', new sfValidatorString(array('required' => false)));
+    $this->setValidator('title', new sfValidatorString(array('required' => false, 'max_length' => 64)));
     $this->setValidator('template', new sfValidatorString(array('required' => false)));
   }
 


### PR DESCRIPTION
チケット: https://redmine.openpne.jp/issues/2909