### PR TITLE
(fixed #4106) メール通知送信設定 のエラーメッセージ表示方法を変更

### DIFF
--- a/apps/pc_backend/modules/mail/actions/actions.class.php
+++ b/apps/pc_backend/modules/mail/actions/actions.class.php
@@ -28,7 +28,6 @@ class mailActions extends sfActions
 
         $this->redirect('@mail_config');
       }
-      $this->getUser()->setFlash('error', (string)$this->form->getErrorSchema(), false);
     }
   }
 

--- a/apps/pc_backend/modules/mail/templates/configSuccess.php
+++ b/apps/pc_backend/modules/mail/templates/configSuccess.php
@@ -5,6 +5,7 @@
 <h2><?php echo __('Configuration of E-mail Notifications') ?></h2>
 
 <?php echo $form->renderFormTag(url_for('@mail_config')); ?>
+<?php echo $form->renderGlobalErrors() ?>
 <?php echo $form->renderHiddenFields(); ?>
 <?php foreach ($config as $target => $mails): ?>
 


### PR DESCRIPTION
Bugチケット: https://redmine.openpne.jp/issues/4106