### PR TITLE
(fixed #4105) コミュニティカテゴリ設定 カテゴリ名称変更時のエラーメッセージが翻訳されるように修正

### DIFF
--- a/apps/pc_backend/modules/community/actions/actions.class.php
+++ b/apps/pc_backend/modules/community/actions/actions.class.php
@@ -203,7 +203,8 @@ class communityActions extends sfActions
       }
       else
       {
-        $this->getUser()->setFlash('error', $form['name']->getError()->getMessage());
+        $i18n = $this->getContext()->getI18N();
+        $this->getUser()->setFlash('error', $i18n->__($form->getWidgetSchema()->getLabel('name'), null, 'form_community').':'.$i18n->__($form['name']->getError()->getMessageFormat(), $form['name']->getError()->getArguments()));
       }
     }
     $this->redirect('community/categoryList');

--- a/apps/pc_backend/modules/community/actions/actions.class.php
+++ b/apps/pc_backend/modules/community/actions/actions.class.php
@@ -204,7 +204,7 @@ class communityActions extends sfActions
       else
       {
         $i18n = $this->getContext()->getI18N();
-        $this->getUser()->setFlash('error', $i18n->__($form->getWidgetSchema()->getLabel('name'), null, 'form_community').':'.$i18n->__($form['name']->getError()->getMessageFormat(), $form['name']->getError()->getArguments()));
+        $this->getUser()->setFlash('error', $i18n->__($form['name']->renderLabelName(), null, 'form_community').':'.$i18n->__($form['name']->getError()->getMessageFormat(), $form['name']->getError()->getArguments()));
       }
     }
     $this->redirect('community/categoryList');

--- a/apps/pc_backend/modules/community/actions/actions.class.php
+++ b/apps/pc_backend/modules/community/actions/actions.class.php
@@ -204,7 +204,7 @@ class communityActions extends sfActions
       else
       {
         $i18n = $this->getContext()->getI18N();
-        $this->getUser()->setFlash('error', $i18n->__($form['name']->renderLabelName(), null, 'form_community').':'.$i18n->__($form['name']->getError()->getMessageFormat(), $form['name']->getError()->getArguments()));
+        $this->getUser()->setFlash('error', $form['name']->renderLabelName().':'.$i18n->__($form['name']->getError()->getMessageFormat(), $form['name']->getError()->getArguments()));
       }
     }
     $this->redirect('community/categoryList');


### PR DESCRIPTION
Bugチケット: https://redmine.openpne.jp/issues/4105