### PR TITLE
(fixed #4107) max_length のエラーメッセージを翻訳カタログに追加

### DIFF
--- a/apps/pc_backend/i18n/form_community.ja.xml
+++ b/apps/pc_backend/i18n/form_community.ja.xml
@@ -42,6 +42,10 @@
         <source>Required.</source>
         <target>必須項目です。</target>
       </trans-unit>
+      <trans-unit id="">
+        <source>"%value%" is too long (%max_length% characters max).</source>
+        <target>%max_length%文字以内で入力してください。</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Bugチケット: https://redmine.openpne.jp/issues/4107