### PR TITLE
fix query hash for caching consider to the number of placeholder will vary depending on the execute() params (fixes #4131)

### DIFF
--- a/lib/util/opDoctrineQuery.class.php
+++ b/lib/util/opDoctrineQuery.class.php
@@ -217,6 +217,25 @@ class opDoctrineQuery extends Doctrine_Query
     return $this;
   }
 
+  public function execute($params = array(), $hydrationMode = null)
+  {
+    $origWhereInCount = $this->whereInCount;
+
+    foreach ($params as $param)
+    {
+      if (is_array($param))
+      {
+        $this->addWhereInCount(count($param));
+      }
+    }
+
+    $results = parent::execute($params, $hydrationMode);
+
+    $this->whereInCount = $origWhereInCount;
+
+    return $results;
+  }
+
   public function calculateQueryCacheHash()
   {
     if ($this->cachedQueryCacheHash)

--- a/test/unit/util/opDoctrineQueryTest.php
+++ b/test/unit/util/opDoctrineQueryTest.php
@@ -86,3 +86,16 @@ $t->isnt($keys['find_one_by_id_and_username'], $keys['find_by_username_and_passw
 $t->isnt($keys['find_one_by_id_and_username'], $keys['find_one_by_username_and_password'], '->findOneByIdAndUsername() and ->findOneByUsernameAndPassword() generates different query cache keys');
 
 $t->isnt($keys['find_by_username_and_password'], $keys['find_one_by_username_and_password'], '->findByUsernameAndPassword() and ->findOneByUsernameAndPassword() generates different query cache keys');
+
+$t->diag('opDoctrineQuery::execute() (#4131)');
+
+$whereInQuery = Doctrine_Core::getTable('AdminUser')->createQuery()
+  ->andWhere('id IN ?');
+
+$whereInQuery->execute(array(array(1)));
+$keys['where_in_one'] = myQuery::$lastQueryCacheHash;
+
+$whereInQuery->execute(array(array(1, 2)));
+$keys['where_in_two'] = myQuery::$lastQueryCacheHash;
+
+$t->isnt($keys['where_in_one'], $keys['where_in_two'], '->execute([[1]]) and ->execute([[1, 2]]) generates different query cache keys');


### PR DESCRIPTION
Bug (バグ) #4131: Doctrine_Query::execute() の $params に応じて WHERE ... IN の要素数が変化する場合にクエリキャッシュが対応できていない
https://redmine.openpne.jp/issues/4131