### PR TITLE
MemberConfigForm::isUnique() のエラーメッセージの翻訳に関する複数の修正 (fixes #4044, #4046; BP from #3999, #4000)

### DIFF
--- a/i18n/messages.ja.xml
+++ b/i18n/messages.ja.xml
@@ -83,8 +83,8 @@
         <target>上に表示されているキーワードを入力してください。</target>
       </trans-unit>
       <trans-unit id="">
-        <source>Invalid mobile_address.</source>
-        <target>メールアドレスが無効です。</target>
+        <source>Invalid %name%.</source>
+        <target>不正な %name% です。</target>
       </trans-unit>
       <trans-unit id="">
         <source>Mon</source>

--- a/i18n/messages.ja.xml
+++ b/i18n/messages.ja.xml
@@ -83,10 +83,6 @@
         <target>上に表示されているキーワードを入力してください。</target>
       </trans-unit>
       <trans-unit id="">
-        <source>Invalid %name%.</source>
-        <target>不正な %name% です。</target>
-      </trans-unit>
-      <trans-unit id="">
         <source>Mon</source>
         <target>月</target>
       </trans-unit>

--- a/lib/form/doctrine/MemberConfigForm.class.php
+++ b/lib/form/doctrine/MemberConfigForm.class.php
@@ -125,6 +125,8 @@ class MemberConfigForm extends BaseForm
         'empty_value' => $this->validatorSchema[$name]->getOption('empty_value'),
       ));
 
+      $uniqueValidator->addMessage('duplicate', 'Invalid %name%.');
+
       $this->validatorSchema[$name] = new sfValidatorAnd(array(
         $this->validatorSchema[$name],
         $uniqueValidator,
@@ -229,7 +231,7 @@ class MemberConfigForm extends BaseForm
       return $value;
     }
 
-    throw new sfValidatorError($validator, 'Invalid %name%.', array('name' => $name));
+    throw new sfValidatorError($validator, 'duplicate', array('name' => $name));
   }
 
   public function isValid()

--- a/lib/form/doctrine/MemberConfigForm.class.php
+++ b/lib/form/doctrine/MemberConfigForm.class.php
@@ -125,7 +125,7 @@ class MemberConfigForm extends BaseForm
         'empty_value' => $this->validatorSchema[$name]->getOption('empty_value'),
       ));
 
-      $uniqueValidator->addMessage('duplicate', 'Invalid %name%.');
+      $uniqueValidator->addMessage('duplicate', 'The inputted value is already exist.');
 
       $this->validatorSchema[$name] = new sfValidatorAnd(array(
         $this->validatorSchema[$name],
@@ -231,7 +231,7 @@ class MemberConfigForm extends BaseForm
       return $value;
     }
 
-    throw new sfValidatorError($validator, 'duplicate', array('name' => $name));
+    throw new sfValidatorError($validator, 'duplicate');
   }
 
   public function isValid()


### PR DESCRIPTION
Backport (バックポート) #4044: MemberConfigFormとMemberProfileFormでIsUnique制約に対するエラーメッセージが統一されていない
https://redmine.openpne.jp/issues/4044

Backport (バックポート) #4046: MemberConfigFormのIsUnique制約に対するエラーメッセージが適切に出力されていない
https://redmine.openpne.jp/issues/4046

上記のバグチケットに対する修正です。一方のみの修正ではコンフリクトが生じるため 1 つの Pull Request にまとめています。
