### PR TITLE
set default settings when retrieving openpne_member_config (fixes #4146, BP from #4034)

### DIFF
--- a/lib/form/doctrine/MemberConfigForm.class.php
+++ b/lib/form/doctrine/MemberConfigForm.class.php
@@ -137,7 +137,7 @@ class MemberConfigForm extends BaseForm
     }
     $this->validatorSchema[$name] = opFormItemGenerator::generateValidator($config);
 
-    if (!empty($config['IsUnique']))
+    if ($config['IsUnique'])
     {
       $uniqueValidator = new sfValidatorCallback(array(
         'callback'    => array($this, 'isUnique'),
@@ -155,7 +155,7 @@ class MemberConfigForm extends BaseForm
       ));
     }
 
-    if (!empty($config['IsConfirm']))
+    if ($config['IsConfirm'])
     {
       $this->validatorSchema[$name.'_confirm'] = $this->validatorSchema[$name];
       $this->widgetSchema[$name.'_confirm'] = $this->widgetSchema[$name];
@@ -171,7 +171,7 @@ class MemberConfigForm extends BaseForm
       )));
     }
 
-    if (!empty($config['Info']))
+    if ($config['Info'])
     {
       $this->widgetSchema->setHelp($name, $config['Info']);
     }
@@ -263,7 +263,7 @@ class MemberConfigForm extends BaseForm
 
     foreach ($this->getValues() as $key => $value)
     {
-      if (!empty($this->memberConfigSettings[$key]['IsUnique']))
+      if ($this->memberConfigSettings[$key]['IsUnique'])
       {
         $memberConfig = Doctrine::getTable('MemberConfig')->retrieveByNameAndValue($key.'_pre', $value);
         if ($memberConfig)

--- a/lib/form/doctrine/MemberConfigForm.class.php
+++ b/lib/form/doctrine/MemberConfigForm.class.php
@@ -95,14 +95,16 @@ class MemberConfigForm extends BaseForm
     $categories = sfConfig::get('openpne_member_category');
     $configs = sfConfig::get('openpne_member_config');
 
-    if (!$this->category) {
-      $this->memberConfigSettings = $configs;
-      return true;
-    }
-
-    foreach ($categories[$this->category] as $value)
+    if (!$this->category)
     {
-      $this->memberConfigSettings[$value] = $configs[$value];
+      $this->memberConfigSettings = $configs;
+    }
+    else
+    {
+      foreach ($categories[$this->category] as $value)
+      {
+        $this->memberConfigSettings[$value] = $configs[$value];
+      }
     }
   }
 

--- a/lib/form/doctrine/MemberConfigForm.class.php
+++ b/lib/form/doctrine/MemberConfigForm.class.php
@@ -106,6 +106,24 @@ class MemberConfigForm extends BaseForm
         $this->memberConfigSettings[$value] = $configs[$value];
       }
     }
+
+    foreach ($this->memberConfigSettings as $configName => $configSettings)
+    {
+      if (null === $configSettings)
+      {
+        continue;
+      }
+
+      // Set default values if key not in array
+      $this->memberConfigSettings[$configName] = $configSettings + array(
+        'IsRegist' => false,
+        'IsConfig' => false,
+        'IsRequired' => false,
+        'IsUnique' => false,
+        'IsConfirm' => false,
+        'Info' => '',
+      );
+    }
   }
 
   public function setMemberConfigWidget($name)


### PR DESCRIPTION
Backport (バックポート) #4146: member/registerInputアクションでメンバー登録のフォームを生成する際にE_NOTICEエラーが発生する
https://redmine.openpne.jp/issues/4146