### PR TITLE
apply is_allow_web_public_flag_age setting to register-input form (fixes #3494, BP from #3453)

### DIFF
--- a/lib/form/MemberConfigForm/MemberConfigPublicFlagForm.class.php
+++ b/lib/form/MemberConfigForm/MemberConfigPublicFlagForm.class.php
@@ -27,16 +27,5 @@ class MemberConfigPublicFlagForm extends MemberConfigForm
     {
       unset($this['profile_page_public_flag']);
     }
-
-    if (!opConfig::get('is_allow_web_public_flag_age'))
-    {
-      $widget = $this->widgetSchema['age_public_flag'];
-
-      $choices = $widget->getOption('choices');
-      unset($choices[4]);
-      $widget->setOption('choices', $choices);
-
-      $this->validatorSchema['age_public_flag']->setOption('choices', array_keys($choices));
-    }
   }
 }

--- a/lib/form/doctrine/MemberConfigForm.class.php
+++ b/lib/form/doctrine/MemberConfigForm.class.php
@@ -95,6 +95,12 @@ class MemberConfigForm extends BaseForm
     $categories = sfConfig::get('openpne_member_category');
     $configs = sfConfig::get('openpne_member_config');
 
+    if (!opConfig::get('is_allow_web_public_flag_age') && isset($configs['age_public_flag']['Choices'][4]))
+    {
+      // Remove `All Users on the Web` choice from age_public_flag setting
+      unset($configs['age_public_flag']['Choices'][4]);
+    }
+
     if (!$this->category) {
       $this->memberConfigSettings = $configs;
       return true;


### PR DESCRIPTION
Backport (バックポート) #3494: 管理画面で「Web 全体への年齢公開許可設定」を「メンバーの設定を許可しない」に設定しても新規登録時には選択できてしまう
https://redmine.openpne.jp/issues/3494