### PR TITLE
add a requirement not to register the secret password with null character (fixes #3504)

### DIFF
--- a/plugins/opAuthMailAddressPlugin/lib/form/opAuthRegisterFormMailAddress.class.php
+++ b/plugins/opAuthMailAddressPlugin/lib/form/opAuthRegisterFormMailAddress.class.php
@@ -32,7 +32,7 @@ class opAuthRegisterFormMailAddress extends opAuthRegisterForm
   public function bindAll($request)
   {
     // this is just hack for limitation of MemberConfigForm
-    if (isset($request['member_config']['secret_answer']))
+    if (isset($request['member_config']['secret_answer']) || '' === $request['member_config']['secret_answer'])
     {
       $memberConfig = $request['member_config'];
       $memberConfig['secret_answer'] = md5($memberConfig['secret_answer']);

--- a/plugins/opAuthMailAddressPlugin/lib/form/opAuthRegisterFormMailAddress.class.php
+++ b/plugins/opAuthMailAddressPlugin/lib/form/opAuthRegisterFormMailAddress.class.php
@@ -32,7 +32,7 @@ class opAuthRegisterFormMailAddress extends opAuthRegisterForm
   public function bindAll($request)
   {
     // this is just hack for limitation of MemberConfigForm
-    if (isset($request['member_config']['secret_answer']) || '' === $request['member_config']['secret_answer'])
+    if (isset($request['member_config']['secret_answer']) && '' !== $request['member_config']['secret_answer'])
     {
       $memberConfig = $request['member_config'];
       $memberConfig['secret_answer'] = md5($memberConfig['secret_answer']);


### PR DESCRIPTION
Bug（バグ） #3504
新規登録時に「秘密の質問への答え」が空欄のままでも登録できてしまう
https://redmine.openpne.jp/issues/3504

Closes #228