### PR TITLE
allow passing null to opI18N::__() method (fixes #4229, BP from #4168)

### DIFF
--- a/lib/i18n/opI18N.class.php
+++ b/lib/i18n/opI18N.class.php
@@ -108,6 +108,11 @@ class opI18N extends sfI18N
 
   public function __($string, $args = array(), $catalogue = 'messages')
   {
+    if (null === $args)
+    {
+      $args = array();
+    }
+
     foreach ($args as $k => $v)
     {
       if ($v instanceof SnsTerm)

--- a/lib/i18n/opI18N.class.php
+++ b/lib/i18n/opI18N.class.php
@@ -108,6 +108,14 @@ class opI18N extends sfI18N
 
   public function __($string, $args = array(), $catalogue = 'messages')
   {
+    foreach ($args as $k => $v)
+    {
+      if ($v instanceof SnsTerm)
+      {
+        $args[$k] = (string)$v;
+      }
+    }
+
     if (empty($this->parsed[$string]))
     {
       $this->parsed[$string] = array();
@@ -135,19 +143,6 @@ class opI18N extends sfI18N
       }
     }
 
-    $parsedString = $this->parsed[$string];
-    if (is_array($args))
-    {
-      foreach ($args as $k => $v)
-      {
-        if ($v instanceof SnsTerm)
-        {
-          $args[$k] = (string)$v;
-        }
-      }
-      $parsedString = array_merge($parsedString, $args);
-    }
-
-    return parent::__($string, $parsedString, $catalogue);
+    return parent::__($string, array_merge($this->parsed[$string], $args), $catalogue);
   }
 }

--- a/test/unit/i18n/opI18nTest.php
+++ b/test/unit/i18n/opI18nTest.php
@@ -1,0 +1,25 @@
+<?php
+
+require_once __DIR__.'/../../bootstrap/unit.php';
+require_once __DIR__.'/../../bootstrap/database.php';
+
+$t = new lime_test();
+
+$t->diag('opI18N::__()');
+
+$i18n = new opI18N($configuration, new sfNoCache(), array('culture' => 'en'));
+
+$t->is($i18n->__('@@ %my_friend% @@'), '@@ my friend @@');
+$t->is($i18n->__('@@ %My_friend% @@'), '@@ My friend @@');
+
+$t->info('#1759: passing null to parameters');
+
+$t->is($i18n->__('@@ %my_friend% @@', null), '@@ my friend @@');
+
+$t->info('#4168: passing SnsTerm instance to parameters');
+
+// purge cache in opI18N::$parsed
+$i18n = new opI18N($configuration, new sfNoCache(), array('culture' => 'en'));
+
+$term = Doctrine_Core::getTable('SnsTerm')->get('my_friend');
+$t->is($i18n->__('@@ %my_friend% @@', array('%my_friend%' => $term->titleize())), '@@ My Friend @@');


### PR DESCRIPTION
Backport (バックポート) #4229: opI18N::__() のパラメータに語形変化の設定をしたSnsTermインスタンスを渡しても反映されない
https://redmine.openpne.jp/issues/4229