### PR TITLE
(fixed #4270, BP from #4267) SNS内名称設定を行った際、navigation のキャッシュクリアを行うように変更

### DIFF
--- a/apps/pc_backend/i18n/messages.ja.xml
+++ b/apps/pc_backend/i18n/messages.ja.xml
@@ -1465,6 +1465,14 @@
         <source>%Community% Sub Administrator</source>
         <target>%Community%副管理者</target>
       </trans-unit>
+      <trans-unit id="">
+        <source>When the following values are set in "Entry name", the setting value in "Term Configuration in this SNS" is reflected in the navigation.</source>
+        <target>「項目名」に下記の値が設定されている場合、SNS内名称設定の設定値がナビゲーションに反映されます。</target>
+      </trans-unit>
+      <trans-unit id="">
+        <source>If it is not reflected, clear the caches in "Cache Clear" in "SNS".</source>
+        <target>反映されない場合は、SNS設定→キャッシュの削除にてキャッシュの削除を行ってください。</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/apps/pc_backend/modules/navigation/templates/listSuccess.php
+++ b/apps/pc_backend/modules/navigation/templates/listSuccess.php
@@ -6,6 +6,37 @@
 
 <h2><?php echo __('Navigation settings') ?></h2>
 
+<p><?php echo __('When the following values are set in "Entry name", the setting value in "Term Configuration in this SNS" is reflected in the navigation.') ?></p>
+<p><?php echo __('If it is not reflected, clear the caches in "Cache Clear" in "SNS".'); ?></p>
+<div>
+  <table>
+    <tr>
+      <th><?php echo __('%Friend%') ?></th>
+      <td>%friend%</td>
+    </tr>
+    <tr>
+      <th><?php echo __('%my_friend%') ?></th>
+      <td>%my_friend%</td>
+    </tr>
+    <tr>
+      <th><?php echo __('%Community%') ?></th>
+      <td>%community%</td>
+    </tr>
+    <tr>
+      <th><?php echo __('%Nickname%') ?></th>
+      <td>%nickname%</td>
+    </tr>
+    <tr>
+      <th><?php echo __('%Activity%') ?></th>
+      <td>%activity%</td>
+    </tr>
+    <tr>
+      <th><?php echo __('%post_activity%') ?></th>
+      <td>%post_activity%</td>
+    </tr>
+  </table>
+</div>
+
 <?php foreach ($list as $type => $nav) : ?>
 <h3><?php echo $type ?></h3>
 

--- a/apps/pc_backend/modules/sns/actions/actions.class.php
+++ b/apps/pc_backend/modules/sns/actions/actions.class.php
@@ -68,6 +68,7 @@ class snsActions extends sfActions
       if ($this->form->isValid())
       {
         $this->form->save();
+        $this->removeNavCaches();
         $this->getUser()->setFlash('notice', 'Saved.');
         $this->redirect('sns/term');
       }
@@ -111,5 +112,30 @@ class snsActions extends sfActions
       $this->getUser()->setFlash('notice', 'Caches are now cleared.');
       $this->redirect('sns/cache');
     }
+  }
+
+  private function removeNavCaches()
+  {
+    $currentApp = sfContext::getInstance()->getConfiguration()->getApplication();
+    $cacheApp = 'pc_frontend';
+
+    if (!sfContext::hasInstance($cacheApp))
+    {
+      sfContext::createInstance(
+        ProjectConfiguration::getApplicationConfiguration(
+          $cacheApp,
+          $this->getContext()->getConfiguration()->getEnvironment(),
+          $this->getContext()->getConfiguration()->isDebug()
+        )
+      );
+    }
+
+    sfContext::switchTo($cacheApp);
+    if ($cache = sfContext::getInstance($cacheApp)->getViewCacheManager())
+    {
+      $cache->remove('@sf_cache_partial?module=default&action=_globalNav&sf_cache_key=*');
+      $cache->remove('@sf_cache_partial?module=default&action=_localNav&sf_cache_key=*');
+    }
+    sfContext::switchTo($currentApp);
   }
 }

--- a/apps/pc_frontend/modules/default/templates/_globalNav.php
+++ b/apps/pc_frontend/modules/default/templates/_globalNav.php
@@ -2,7 +2,7 @@
 <ul>
 <?php foreach ($navs as $nav): ?>
 <?php if (op_is_accessible_url($nav->uri)): ?>
-<li id="globalNav_<?php echo op_url_to_id($nav->uri) ?>"><?php echo link_to($nav->caption, $nav->uri) ?></li>
+<li id="globalNav_<?php echo op_url_to_id($nav->uri) ?>"><?php echo link_to(__($nav->caption), $nav->uri) ?></li>
 <?php endif; ?>
 <?php endforeach; ?>
 </ul>

--- a/apps/pc_frontend/modules/default/templates/_localNav.php
+++ b/apps/pc_frontend/modules/default/templates/_localNav.php
@@ -9,7 +9,7 @@
 <?php endif; ?>
 
 <?php if (op_is_accessible_url($uri)): ?>
-<li id="<?php echo $nav->type ?>_<?php echo op_url_to_id($nav->uri) ?>"><?php echo link_to($nav->caption, $uri); ?></li>
+<li id="<?php echo $nav->type ?>_<?php echo op_url_to_id($nav->uri) ?>"><?php echo link_to(__($nav->caption), $uri); ?></li>
 <?php endif; ?>
 
 <?php endforeach; ?>

--- a/data/fixtures/004_import_navi_menu.yml
+++ b/data/fixtures/004_import_navi_menu.yml
@@ -25,7 +25,7 @@ Navigation:
     sort_order: 20
     Translation:
       ja_JP:
-        caption: "コミュニティ検索"
+        caption: "%community%検索"
       en:
         caption: "Search Communities"
 
@@ -45,7 +45,7 @@ Navigation:
     sort_order: 40
     Translation:
       ja_JP:
-        caption: "友人を招待する"
+        caption: "%friend%を招待する"
       en:
         caption: "Invite"
 
@@ -75,7 +75,7 @@ Navigation:
     sort_order: 10
     Translation:
       ja_JP:
-        caption: "マイフレンド"
+        caption: "%my_friend%"
       en:
         caption: "My Friends"
 
@@ -115,7 +115,7 @@ Navigation:
     sort_order: 20
     Translation:
       ja_JP:
-        caption: "フレンドリスト"
+        caption: "%friend%リスト"
       en:
         caption: "Friends"
 
@@ -125,9 +125,9 @@ Navigation:
     sort_order: 0
     Translation:
       ja_JP:
-        caption: "コミュニティトップ"
+        caption: "%community%トップ"
       en:
-        caption: "Community Top"
+        caption: "%Community% Top"
 
   community_navigation_join:
     type: "community"
@@ -135,9 +135,9 @@ Navigation:
     sort_order: 10
     Translation:
       ja_JP:
-        caption: "コミュニティに参加"
+        caption: "%community%に参加"
       en:
-        caption: "Join Community"
+        caption: "Join %Community%"
 
   community_navigation_quit:
     type: "community"
@@ -145,6 +145,6 @@ Navigation:
     sort_order: 20
     Translation:
       ja_JP:
-        caption: "コミュニティを退会"
+        caption: "%community%を退会"
       en:
-        caption: "Leave Community"
+        caption: "Leave %Community%"

--- a/test/fixtures/common/test_data.yml
+++ b/test/fixtures/common/test_data.yml
@@ -430,9 +430,9 @@ Navigation:
     sort_order: 0
     Translation:
       ja_JP:
-        caption: "コミュニティトップ"
+        caption: "%community%トップ"
       en:
-        caption: "Community Top"
+        caption: "%Community% Top"
 
 MemberRelationship:
   first_member_second_member:


### PR DESCRIPTION
http://redmine.openpne.jp/issues/4100 が適用されていることが必要です