### PR TITLE
allow internal uri (the 'url_for()' format) for notification url (fixes #4055)

### DIFF
--- a/apps/api/lib/helper/opJsonApiHelper.php
+++ b/apps/api/lib/helper/opJsonApiHelper.php
@@ -193,6 +193,25 @@ function op_api_notification($notification)
     $iconUrl = sf_image_path($iconUrl, array('size' => '48x48'), true);
   }
 
+  $url = null;
+  if (null !== $notification['url'] && '' !== $notification['url'])
+  {
+    if ('/' === $notification['url'][0])
+    {
+      // Backward compatibility before OpenPNE 3.8.24.
+      // Basically, those URLs begin with relative URL root (ex. "/subdir/member/1").
+      $url = $notification['url'];
+    }
+    elseif (0 === strpos($notification['url'], 'http://') || 0 === strpos($notification['url'], 'https://'))
+    {
+      $url = $notification['url'];
+    }
+    else
+    {
+      $url = app_url_for('pc_frontend', $notification['url'], true);
+    }
+  }
+
   return array(
     'id' => $notification['id'],
     'body' => sfContext::getInstance()->getI18N()->__($notification['body']),
@@ -200,7 +219,7 @@ function op_api_notification($notification)
     'unread' => $notification['unread'],
     'created_at' => date('r', strtotime($notification['created_at'])),
     'icon_url' => $iconUrl,
-    'url' => $notification['url'] ? url_for($notification['url'], array('abstract' => true)) : null,
+    'url' => $url,
     'member_id_from' => $notification['member_id_from'],
   );
 }

--- a/apps/api/lib/helper/opJsonApiHelper.php
+++ b/apps/api/lib/helper/opJsonApiHelper.php
@@ -202,7 +202,7 @@ function op_api_notification($notification)
       // Basically, those URLs begin with relative URL root (ex. "/subdir/member/1").
       $url = $notification['url'];
     }
-    elseif (0 === strpos($notification['url'], 'http://') || 0 === strpos($notification['url'], 'https://'))
+    elseif (preg_match('#^https?://#i', $notification['url']))
     {
       $url = $notification['url'];
     }

--- a/test/functional/api/pushSearchActionTest.php
+++ b/test/functional/api/pushSearchActionTest.php
@@ -1,0 +1,119 @@
+<?php
+
+$executeLoader = false;
+require_once __DIR__.'/../../bootstrap/functional.php';
+require_once __DIR__.'/../../bootstrap/database.php';
+
+$numberOfTests = 12;
+$browser = new opBrowser();
+$tester = new opTestFunctional($browser, new lime_test($numberOfTests));
+
+$t = $tester->test();
+
+Doctrine_Core::getTable('SnsConfig')->set('enable_jsonapi', true);
+$member1 = Doctrine_Core::getTable('Member')->find(1);
+$member1ApiKey = $member1->getApiKey();
+$member2 = Doctrine_Core::getTable('Member')->find(2);
+
+$testcases = array();
+
+$testcases[] = function($t, $tester)
+{
+  global $browser, $member1, $member1ApiKey, $member2;
+
+  $t->diag('/push/search.json - backward compatibility (url begins with "/")');
+
+  opNotificationCenter::notify($member2, $member1, 'test', array(
+    'url' => '/member/1',
+  ));
+
+  $browser->rawConfiguration['op_base_url'] = 'http://localhost/subdir';
+
+  $tester
+    ->get('/push/search.json', array('apiKey' => $member1ApiKey))
+    ->isStatusCode(200);
+
+  $json = $tester->getResponse()->getContent();
+  $data = json_decode($json, true);
+
+  $t->is($data['status'], 'success');
+  $t->is($data['data'][0]['url'], '/member/1');
+};
+
+$testcases[] = function($t, $tester)
+{
+  global $browser, $member1, $member1ApiKey, $member2;
+
+  $t->diag('/push/search.json - internal uri (not begins with "/", "@")');
+
+  opNotificationCenter::notify($member2, $member1, 'test', array(
+    'url' => 'member/1',
+  ));
+
+  $browser->rawConfiguration['op_base_url'] = 'http://localhost/subdir';
+
+  $tester
+    ->get('/push/search.json', array('apiKey' => $member1ApiKey))
+    ->isStatusCode(200);
+
+  $json = $tester->getResponse()->getContent();
+  $data = json_decode($json, true);
+
+  $t->is($data['status'], 'success');
+  $t->is($data['data'][0]['url'], 'http://localhost/subdir/pc_frontend_test.php/member/1');
+};
+
+$testcases[] = function($t, $tester)
+{
+  global $browser, $member1, $member1ApiKey, $member2;
+
+  $t->diag('/push/search.json - internal uri (begins with "@")');
+
+  opNotificationCenter::notify($member2, $member1, 'test', array(
+    'url' => '@obj_member_profile?id=1',
+  ));
+
+  $browser->rawConfiguration['op_base_url'] = 'http://localhost/subdir';
+
+  $tester
+    ->get('/push/search.json', array('apiKey' => $member1ApiKey))
+    ->isStatusCode(200);
+
+  $json = $tester->getResponse()->getContent();
+  $data = json_decode($json, true);
+
+  $t->is($data['status'], 'success');
+  $t->is($data['data'][0]['url'], 'http://localhost/subdir/pc_frontend_test.php/member/1');
+};
+
+$testcases[] = function($t, $tester)
+{
+  global $browser, $member1, $member1ApiKey, $member2;
+
+  $t->diag('/push/search.json - absolute url');
+
+  opNotificationCenter::notify($member2, $member1, 'test', array(
+    'url' => 'http://www.google.com/',
+  ));
+
+  $browser->rawConfiguration['op_base_url'] = 'http://localhost/subdir';
+
+  $tester
+    ->get('/push/search.json', array('apiKey' => $member1ApiKey))
+    ->isStatusCode(200);
+
+  $json = $tester->getResponse()->getContent();
+  $data = json_decode($json, true);
+
+  $t->is($data['status'], 'success');
+  $t->is($data['data'][0]['url'], 'http://www.google.com/');
+};
+
+$conn = Doctrine_Manager::connection();
+
+foreach ($testcases as $testcase)
+{
+  $conn->beginTransaction();
+  $testcase($t, $tester);
+  $conn->rollback();
+}


### PR DESCRIPTION
Bug (バグ) #4055: OpenPNE が http://example.com/sns/ のようにサブディレクトリ以下に設置されている場合に、通知センターからアクセスする日記やコミュニティのURLが正しくない
https://redmine.openpne.jp/issues/4055

Closes #393