### PR TITLE
set default settings when retrieving openpne_member_config (fixes #4146, BP from #4034)

### DIFF
--- a/lib/form/doctrine/MemberConfigForm.class.php
+++ b/lib/form/doctrine/MemberConfigForm.class.php
@@ -101,14 +101,34 @@ class MemberConfigForm extends BaseForm
       unset($configs['age_public_flag']['Choices'][4]);
     }
 
-    if (!$this->category) {
+    if (!$this->category)
+    {
       $this->memberConfigSettings = $configs;
-      return true;
+    }
+    else
+    {
+      foreach ($categories[$this->category] as $value)
+      {
+        $this->memberConfigSettings[$value] = $configs[$value];
+      }
     }
 
-    foreach ($categories[$this->category] as $value)
+    foreach ($this->memberConfigSettings as $configName => $configSettings)
     {
-      $this->memberConfigSettings[$value] = $configs[$value];
+      if (null === $configSettings)
+      {
+        continue;
+      }
+
+      // Set default values if key not in array
+      $this->memberConfigSettings[$configName] = $configSettings + array(
+        'IsRegist' => false,
+        'IsConfig' => false,
+        'IsRequired' => false,
+        'IsUnique' => false,
+        'IsConfirm' => false,
+        'Info' => '',
+      );
     }
   }
 
@@ -123,7 +143,7 @@ class MemberConfigForm extends BaseForm
     }
     $this->validatorSchema[$name] = opFormItemGenerator::generateValidator($config);
 
-    if (!empty($config['IsUnique']))
+    if ($config['IsUnique'])
     {
       $uniqueValidator = new sfValidatorCallback(array(
         'callback'    => array($this, 'isUnique'),
@@ -143,7 +163,7 @@ class MemberConfigForm extends BaseForm
       ));
     }
 
-    if (!empty($config['IsConfirm']))
+    if ($config['IsConfirm'])
     {
       $this->validatorSchema[$name.'_confirm'] = $this->validatorSchema[$name];
       $this->widgetSchema[$name.'_confirm'] = $this->widgetSchema[$name];
@@ -159,7 +179,7 @@ class MemberConfigForm extends BaseForm
       )));
     }
 
-    if (!empty($config['Info']))
+    if ($config['Info'])
     {
       $this->widgetSchema->setHelp($name, $config['Info']);
     }
@@ -251,7 +271,7 @@ class MemberConfigForm extends BaseForm
 
     foreach ($this->getValues() as $key => $value)
     {
-      if (!empty($this->memberConfigSettings[$key]['IsUnique']))
+      if ($this->memberConfigSettings[$key]['IsUnique'])
       {
         $memberConfig = Doctrine::getTable('MemberConfig')->retrieveByNameAndValue($key.'_pre', $value);
         if ($memberConfig)


### PR DESCRIPTION
Backport (バックポート) #4146: member/registerInputアクションでメンバー登録のフォームを生成する際にE_NOTICEエラーが発生する
https://redmine.openpne.jp/issues/4146