### PR TITLE
fix reference to non-existence .js file (fixes #4381, BP from #4031)

### DIFF
--- a/lib/helper/opJavascriptHelper.php
+++ b/lib/helper/opJavascriptHelper.php
@@ -25,7 +25,7 @@ require_once sfConfig::get('sf_lib_dir').'/helper/JavascriptHelper.php';
  */
 function make_modal_box($id, $contents)
 {
-  sfContext::getInstance()->getResponse()->addJavascript(sfConfig::get('op_jquery_url'));
+  sfContext::getInstance()->getResponse()->addJavascript('jquery.min.js');
   sfContext::getInstance()->getResponse()->addJavascript('util');
   $div = '<div id="'.$id.'" class="modalWall" style="display:none" onclick="$(this).hide(); $(\'#'.$id.'_contents\').hide()"></div>'
        . '<div id="'.$id.'_contents" class="modalBox" style="display: none;">'


### PR DESCRIPTION
Bug（バグ） #4031
存在しない /js/.js を読み込もうとして404エラーが発生している
http://redmine.openpne.jp/issues/4031

Backport（バックポート） #4381
存在しない /js/.js を読み込もうとして404エラーが発生している
http://redmine.openpne.jp/issues/4381