### PR TITLE
(refs #4672, BP from #4668) SNS内名称設定で設定されている項目が翻訳されない場合がある

### DIFF
--- a/lib/config/opApplicationConfiguration.class.php
+++ b/lib/config/opApplicationConfiguration.class.php
@@ -215,10 +215,6 @@ abstract class opApplicationConfiguration extends sfApplicationConfiguration
 
     $table = Doctrine::getTable('SnsTerm');
     $application = sfConfig::get('sf_app');
-    if (in_array($application, array('pc_backend', 'api'), true))
-    {
-        $application = 'pc_frontend';
-    }
     $table->configure(sfContext::getInstance()->getUser()->getCulture(), $application);
     $parameters['op_term'] = $table;
     sfOutputEscaper::markClassAsSafe('SnsTermTable');

--- a/lib/i18n/opI18N.class.php
+++ b/lib/i18n/opI18N.class.php
@@ -20,18 +20,9 @@ class opI18N extends sfI18N
   {
     parent::initialize($configuration, $cache, $options);
 
-    $this->terms = Doctrine::getTable('SnsTerm');
     $application = sfConfig::get('sf_app');
-    if (in_array($application, array('pc_backend', 'api'), true))
-    {
-        $application = 'pc_frontend';
-    }
     $this->terms = Doctrine::getTable('SnsTerm');
     $this->terms->configure($this->culture, $application);
-    if (!$this->terms['member'])
-    {
-      $this->terms->configure('en', $application);
-    }
   }
 
   public function generateApplicationMessages($dirs)

--- a/lib/model/doctrine/SnsTermTable.class.php
+++ b/lib/model/doctrine/SnsTermTable.class.php
@@ -17,14 +17,21 @@ class SnsTermTable extends Doctrine_Table implements ArrayAccess
 
   public function configure($culture = '', $application = '')
   {
-    if ($culture)
+    if (in_array($application, array('pc_backend', 'api'), true))
     {
-      $this->culture = $culture;
+        $application = 'pc_frontend';
     }
 
-    if ($application)
+    if ($culture && $culture !== $this->culture)
+    {
+      $this->culture = $culture;
+      $this->terms = null;
+    }
+
+    if ($application && $application !== $this->application)
     {
       $this->application = $application;
+      $this->terms = null;
     }
   }
 


### PR DESCRIPTION
SnsTermTable::configure() で pc_backend, api が指定される可能性をなくし、言語アプリケーション切替時は取得済みの terms を空にする